### PR TITLE
feat(worker): add retries with exponential backoff and DLQ support

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -45,3 +45,15 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+groups:
+- name: dlq.rules
+  rules:
+  - alert: DLQGrowing
+    expr: increase(dlq_add_total[10m]) > 10
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      summary: "DLQ additions high ({{ $value }})"
+      description: "DLQ items added increased significantly in the last 10m"

--- a/src/admin.js
+++ b/src/admin.js
@@ -1,0 +1,40 @@
+import express from 'express';
+import { Pool } from 'pg';
+import { workQueue } from './queue';
+
+export function adminRouter(pool) {
+  const router = express.Router();
+
+  // list DLQ items (with pagination)
+  router.get('/dlq', async (req, res) => {
+    const limit = Math.min(100, Number(req.query.limit ?? 50));
+    const offset = Number(req.query.offset ?? 0);
+    const rows = await pool.query(`SELECT * FROM dlq_items ORDER BY failed_at DESC LIMIT $1 OFFSET $2`, [limit, offset]);
+    res.json({ success: true, data: rows.rows });
+  });
+
+  // inspect single item
+  router.get('/dlq/:id', async (req, res) => {
+    const { id } = req.params;
+    const row = await pool.query(`SELECT * FROM dlq_items WHERE id=$1`, [id]);
+    if (!row.rowCount) return res.status(404).json({ success:false, message: 'Not found' });
+    res.json({ success: true, data: row.rows[0] });
+  });
+
+  // requeue after inspection
+  router.post('/dlq/:id/requeue', async (req, res) => {
+    const { id } = req.params;
+    const row = await pool.query(`SELECT * FROM dlq_items WHERE id=$1`, [id]);
+    if (!row.rowCount) return res.status(404).json({ success:false, message:'Not found' });
+    const item = row.rows[0];
+    // Add back to queue (maintain attempts metadata or reset)
+    await workQueue.add('requeued-job', item.payload, {
+      attempts: Number(process.env.MAX_ATTEMPTS ?? 5),
+      backoff: { type: 'exponential', delay: Number(process.env.BACKOFF_BASE_MS ?? 1000) }
+    });
+    await pool.query(`UPDATE dlq_items SET requeued=true, requeued_at=now() WHERE id=$1`, [id]);
+    res.json({ success: true, message: 'Requeued' });
+  });
+
+  return router;
+}

--- a/src/config/queue.js
+++ b/src/config/queue.js
@@ -1,0 +1,4 @@
+export const QUEUE_NAME = 'jobs';
+export const MAX_ATTEMPTS = 5;
+export const BACKOFF_BASE_MS = 1000;
+export const DLQ_TABLE = 'dlq_items';

--- a/src/queue-setup.js
+++ b/src/queue-setup.js
@@ -1,0 +1,19 @@
+import { Queue } from 'bullmq';
+import IORedis from 'ioredis';
+import { QUEUE_NAME } from './config';
+
+const connection = new IORedis(process.env.REDIS_URL || 'redis://localhost:6379');
+
+export const workQueue = new Queue(QUEUE_NAME, { connection });
+
+export async function enqueueJob(name, payload) {
+  await workQueue.add(name, payload, {
+    attempts: Number(process.env.MAX_ATTEMPTS ?? 5),
+    backoff: {
+      type: 'exponential',
+      delay: Number(process.env.BACKOFF_BASE_MS ?? 1000),
+    },
+    removeOnComplete: true,
+    removeOnFail: false,
+  });
+}

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,65 @@
+import { Worker, QueueEvents, Job } from 'bullmq';
+import IORedis from 'ioredis';
+import { Pool } from 'pg';
+import { QUEUE_NAME, MAX_ATTEMPTS, BACKOFF_BASE_MS } from './config';
+import { saveDLQItem } from './dlqStore';
+import promClient from 'prom-client';
+
+const redis = new IORedis(process.env.REDIS_URL || 'redis://localhost:6379');
+const pg = new Pool({ connectionString: process.env.DATABASE_URL });
+
+const worker = new Worker(QUEUE_NAME, async (job) => {
+  // Your job handler (example)
+  const { data } = job;
+  // perform job; throw on error to trigger retries
+  await doWork(data);
+}, { connection: redis, concurrency: 5 });
+
+const qEvents = new QueueEvents(QUEUE_NAME, { connection: redis });
+
+// Metrics
+const dlqGauge = new promClient.Gauge({ name: 'dlq_size', help: 'Number of items in DLQ' });
+const dlqAddedCounter = new promClient.Counter({ name: 'dlq_add_total', help: 'DLQ items added' });
+
+qEvents.on('failed', async ({ jobId, failedReason }) => {
+  // inspect job using Worker API (Job is not directly available here)
+  try {
+    const job = await worker.getJob(jobId);
+    if (!job) return;
+
+    const attemptsMade = job.attemptsMade ?? 0;
+    const optsAttempts = (job.opts && (job.opts).attempts) ?? MAX_ATTEMPTS;
+
+    if (attemptsMade >= optsAttempts) {
+      // move to DLQ storage
+      await saveDLQItem(pg, {
+        queue_name: QUEUE_NAME,
+        job_id: job.id?.toString(),
+        payload: job.data,
+        attempts: attemptsMade,
+        last_error: failedReason,
+        metadata: {
+          opts: job.opts,
+          timestamp: new Date().toISOString()
+        }
+      });
+
+      dlqAddedCounter.inc();
+      // optionally remove job from failed set (Bull manages failed jobs)
+      await job.remove();
+      // update gauge (simple approach: query count)
+      const res = await pg.query('SELECT count(*) FROM dlq_items');
+      dlqGauge.set(Number(res.rows[0].count));
+    }
+  } catch (err) {
+    console.error('Error handling failed job event', err);
+  }
+});
+
+worker.on('error', err => console.error('Worker error', err));
+
+async function doWork(data) {
+  // Replace with actual work. For demo:
+  if (Math.random() < 0.7) throw new Error('Transient error');
+  return true;
+}


### PR DESCRIPTION
This PR introduces a retry strategy with exponential backoff for job failures and implements a Dead Letter Queue (DLQ) for persistent job failures.

Changes

BullMQ Worker

Added retry policy with exponential backoff (attempts + backoff options).
Subscribed to failed events to detect jobs that exhaust retries.
Persisted failed job payloads + metadata to a Postgres-backed DLQ.
Automatically removed exhausted jobs from the failed set.

DLQ Persistence

Added dlq_items table with schema for job payload, attempts, error info, and metadata.
Added helper function saveDLQItem for persistence.

Admin Endpoints

GET /admin/dlq – list DLQ items with pagination.
GET /admin/dlq/:id – inspect a single DLQ item.
POST /admin/dlq/:id/requeue – requeue a DLQ job for processing.

Metrics

Introduced Prometheus metrics:
dlq_size (gauge)
dlq_add_total (counter)
Ready for alerting integration when DLQ grows abnormally.

Config

Centralized queue name, attempts, and backoff base delay in config.ts.
Acceptance Criteria
 Jobs retried with exponential backoff up to MAX_ATTEMPTS.
 Persistent failures stored in DLQ with payload and error metadata.
 Admins can inspect and requeue DLQ items.
 Metrics emitted for DLQ growth.
Migration

Run the SQL migration to create the DLQ table:

CREATE TABLE dlq_items (
  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
  queue_name TEXT NOT NULL,
  job_id TEXT,
  payload JSONB NOT NULL,
  failed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
  attempts INT NOT NULL,
  last_error TEXT,
  error_stack TEXT,
  metadata JSONB,
  requeued BOOLEAN DEFAULT false,
  requeued_at TIMESTAMPTZ
);