### PR TITLE
feat(payments): add reconciliation job with Mongoose models + manual endpoint

### DIFF
--- a/src/jobs/reconciliationJob.js
+++ b/src/jobs/reconciliationJob.js
@@ -1,0 +1,12 @@
+const cron = require("node-cron");
+const { runReconciliation } = require("../services/reconciliationService");
+const providerClient = require("../providers/stripeClient");
+
+cron.schedule("0 2 * * *", async () => {
+  console.log("Running daily reconciliation...");
+  try {
+    await runReconciliation(providerClient);
+  } catch (err) {
+    console.error("Reconciliation failed:", err.message);
+  }
+});

--- a/src/models/ProviderCursor.js
+++ b/src/models/ProviderCursor.js
@@ -1,0 +1,9 @@
+const mongoose = require("mongoose");
+
+const ProviderCursorSchema = new mongoose.Schema({
+  provider: { type: String, unique: true, required: true },
+  cursor: { type: String },
+  lastReconciledAt: { type: Date },
+}, { timestamps: true });
+
+module.exports = mongoose.model("ProviderCursor", ProviderCursorSchema);

--- a/src/models/ReconciliationItem.js
+++ b/src/models/ReconciliationItem.js
@@ -1,0 +1,17 @@
+const mongoose = require("mongoose");
+
+const ReconciliationItemSchema = new mongoose.Schema({
+  runId: { type: mongoose.Schema.Types.ObjectId, ref: "ReconciliationRun", required: true },
+  providerId: { type: String, required: true },
+  localTransactionId: { type: mongoose.Schema.Types.ObjectId, ref: "Transaction" },
+  type: { 
+    type: String, 
+    enum: ["MISSING_LOCAL", "MISSING_PROVIDER", "AMOUNT_MISMATCH", "REFUND_MISSING", "OTHER"], 
+    required: true 
+  },
+  details: { type: Object },
+  alerted: { type: Boolean, default: false },
+}, { timestamps: true });
+
+module.exports = mongoose.model("ReconciliationItem", ReconciliationItemSchema);
+

--- a/src/models/ReconciliationRun.js
+++ b/src/models/ReconciliationRun.js
@@ -1,0 +1,10 @@
+const mongoose = require("mongoose");
+
+const ReconciliationRunSchema = new mongoose.Schema({
+  provider: { type: String, required: true }, // e.g. stripe, paystack
+  status: { type: String, enum: ["PENDING", "RUNNING", "COMPLETED", "FAILED"], default: "PENDING" },
+  cursor: { type: String },
+  summary: { type: Object },
+}, { timestamps: true });
+
+module.exports = mongoose.model("ReconciliationRun", ReconciliationRunSchema);

--- a/src/routes/reconciliation.js
+++ b/src/routes/reconciliation.js
@@ -1,0 +1,32 @@
+const express = require("express");
+const router = express.Router();
+const { runReconciliation } = require("../services/reconciliationService");
+const ReconciliationRun = require("../models/ReconciliationRun");
+const ReconciliationItem = require("../models/ReconciliationItem");
+
+// Example provider client (Stripe, Paystack, etc.)
+const providerClient = require("../providers/stripeClient");
+
+// POST /reconciliation/:provider/run (manual run)
+router.post("/:provider/run", async (req, res) => {
+  try {
+    const run = await runReconciliation(providerClient, req.query.cursor);
+    res.json(run);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /reconciliation/runs
+router.get("/runs", async (req, res) => {
+  const runs = await ReconciliationRun.find().sort({ createdAt: -1 }).limit(50);
+  res.json(runs);
+});
+
+// GET /reconciliation/runs/:id/items
+router.get("/runs/:id/items", async (req, res) => {
+  const items = await ReconciliationItem.find({ runId: req.params.id });
+  res.json(items);
+});
+
+module.exports = router;

--- a/src/service/reconciliationService.js
+++ b/src/service/reconciliationService.js
@@ -1,0 +1,72 @@
+const ReconciliationRun = require("../models/ReconciliationRun");
+const ReconciliationItem = require("../models/ReconciliationItem");
+const ProviderCursor = require("../models/ProviderCursor");
+const Transaction = require("../models/Transaction"); // your local payments collection
+
+async function runReconciliation(providerClient, manualCursor) {
+  const run = new ReconciliationRun({ provider: providerClient.name, status: "RUNNING", cursor: manualCursor });
+  await run.save();
+
+  try {
+    let cursorDoc = await ProviderCursor.findOne({ provider: providerClient.name });
+    let cursor = manualCursor || (cursorDoc ? cursorDoc.cursor : null);
+
+    let processed = 0, mismatches = 0, nextCursor = cursor;
+
+    do {
+      const { items, nextCursor: providerNext } = await providerClient.listTransactions(nextCursor, 100);
+
+      for (let tx of items) {
+        processed++;
+
+        const mismatch = await compareProviderTxToLocal(tx);
+        if (mismatch) {
+          mismatches++;
+          await ReconciliationItem.create({
+            runId: run._id,
+            providerId: tx.id,
+            localTransactionId: mismatch.localId,
+            type: mismatch.type,
+            details: mismatch.details
+          });
+        }
+      }
+
+      nextCursor = providerNext;
+    } while (nextCursor);
+
+    run.status = "COMPLETED";
+    run.summary = { processed, mismatches };
+    await run.save();
+
+    if (!cursorDoc) {
+      cursorDoc = new ProviderCursor({ provider: providerClient.name });
+    }
+    cursorDoc.cursor = nextCursor;
+    cursorDoc.lastReconciledAt = new Date();
+    await cursorDoc.save();
+
+    return run;
+  } catch (err) {
+    run.status = "FAILED";
+    run.summary = { error: err.message };
+    await run.save();
+    throw err;
+  }
+}
+
+async function compareProviderTxToLocal(pTx) {
+  const localTx = await Transaction.findOne({ providerId: pTx.id });
+  if (!localTx) {
+    return { type: "MISSING_LOCAL", details: { amount: pTx.amount }, localId: null };
+  }
+  if (localTx.amount !== pTx.amount) {
+    return { type: "AMOUNT_MISMATCH", details: { local: localTx.amount, provider: pTx.amount }, localId: localTx._id };
+  }
+  if (pTx.refunded && !localTx.refunded) {
+    return { type: "REFUND_MISSING", details: { providerRefunded: true }, localId: localTx._id };
+  }
+  return null;
+}
+
+module.exports = { runReconciliation };


### PR DESCRIPTION
## Description
Implemented automated reconciliation for payments. A daily cron job compares provider ledger with local DB and stores mismatches for review.

## Changes
- Added models: ReconciliationRun, ReconciliationItem, ProviderCursor
- Service logic to detect mismatches (missing local tx, amount mismatch, missing refunds)
- Express routes for manual reconciliation runs and viewing reports
- node-cron job to run reconciliation daily

## How to Test
- Run server, hit `POST /reconciliation/stripe/run`
- Verify mismatches stored in `reconciliation_items` collection
- Daily cron runs at 2:00 AM

Closes #82
