### PR TITLE
feat(config): validate environment variables on startup

### DIFF
--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-console */
+
+const REQUIRED_ENV_VARS = ['DATABASE_URL', 'JWT_SECRET'];
+
+function isValidUrl(value) {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isValidPort(value) {
+  const port = Number(value);
+  return Number.isInteger(port) && port > 0 && port < 65536;
+}
+
+export function validateEnv() {
+  const errors = [];
+
+  REQUIRED_ENV_VARS.forEach((key) => {
+    if (!process.env[key] || process.env[key].trim() === '') {
+      errors.push(`Missing required env variable: ${key}`);
+    }
+  });
+
+  if (process.env.DATABASE_URL && !isValidUrl(process.env.DATABASE_URL)) {
+    errors.push('DATABASE_URL is not a valid URL');
+  }
+
+  if (process.env.PORT && !isValidPort(process.env.PORT)) {
+    errors.push('PORT must be a valid number');
+  }
+
+  if (errors.length) {
+    console.error('\nEnvironment configuration error:\n');
+    errors.forEach((err) => console.error(`- ${err}`));
+    console.error('\nFix the above and restart the server.\n');
+    process.exit(1);
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import { createRequire } from 'module';
 
+import { validateEnv } from './config/validateEnv.js';
 import i18next from './config/i18n.js';
 import connectDB from './config/database.js';
 import errorHandler from './middleware/errorHandler.js';
@@ -30,8 +31,12 @@ import { initRealtime } from './services/realtime.service.js';
 import http from 'http';
 import { initWebSocket } from './wsServer.js';
 
+
 // Load environment variables
 dotenv.config();
+
+// Validate environment variables
+validateEnv();
 
 // Initialize Express app
 const app = express();


### PR DESCRIPTION
Adds environment variable validation on startup.

The app now fails fast with clear errors when required env vars
are missing or invalid.

Closes #152

---

Note:
While testing locally, the app fails due to a missing
`src/routes/webhookRoutes.js` import referenced in
`src/routes/index.js`. This appears unrelated to this change
and existed prior to this PR.
