### PR TITLE
feat/Monitoring Dashboard Data Endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1648,208 +1648,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-auth": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
-      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-util": "^1.13.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/core-client": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
-      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.10.0",
-        "@azure/core-rest-pipeline": "^1.22.0",
-        "@azure/core-tracing": "^1.3.0",
-        "@azure/core-util": "^1.13.0",
-        "@azure/logger": "^1.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/core-http-compat": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.3.2.tgz",
-      "integrity": "sha512-Tf6ltdKzOJEgxZeWLCjMxrxbodB/ZeCbzzA1A2qHbhzAjzjHoBVSUeSl/baT/oHAxhc4qdqVaDKnc2+iE932gw==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@azure/core-client": "^1.10.0",
-        "@azure/core-rest-pipeline": "^1.22.0"
-      }
-    },
-    "node_modules/@azure/core-lro": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
-      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-util": "^1.2.0",
-        "@azure/logger": "^1.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-paging": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
-      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
-      "integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.10.0",
-        "@azure/core-tracing": "^1.3.0",
-        "@azure/core-util": "^1.13.0",
-        "@azure/logger": "^1.3.0",
-        "@typespec/ts-http-runtime": "^0.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/core-tracing": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
-      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/core-util": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
-      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@typespec/ts-http-runtime": "^0.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/core-xml": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.0.tgz",
-      "integrity": "sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-parser": "^5.0.7",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/logger": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
-      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@typespec/ts-http-runtime": "^0.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/storage-blob": {
-      "version": "12.31.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.31.0.tgz",
-      "integrity": "sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-client": "^1.9.3",
-        "@azure/core-http-compat": "^2.2.0",
-        "@azure/core-lro": "^2.2.0",
-        "@azure/core-paging": "^1.6.2",
-        "@azure/core-rest-pipeline": "^1.19.1",
-        "@azure/core-tracing": "^1.2.0",
-        "@azure/core-util": "^1.11.0",
-        "@azure/core-xml": "^1.4.5",
-        "@azure/logger": "^1.1.4",
-        "@azure/storage-common": "^12.3.0",
-        "events": "^3.0.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/storage-common": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.3.0.tgz",
-      "integrity": "sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-http-compat": "^2.2.0",
-        "@azure/core-rest-pipeline": "^1.19.1",
-        "@azure/core-tracing": "^1.2.0",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.1.4",
-        "events": "^3.3.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "dev": true,
@@ -7952,20 +7750,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.3.tgz",
-      "integrity": "sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==",
-      "license": "MIT",
-      "dependencies": {
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "dev": true,
@@ -10645,15 +10429,6 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
@@ -16067,11 +15842,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/ot": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/ot/-/ot-0.0.15.tgz",
-      "integrity": "sha512-Bl7YcrV+R+UPPi1cWocHH8oUh1qaYEZdzRep5PpXesfN62PUrez92m17Za5+E1SWgtIx7SsvcH5yLliWEKhcCA=="
     },
     "node_modules/p-defer": {
       "version": "4.0.1",

--- a/src/controllers/queueController.js
+++ b/src/controllers/queueController.js
@@ -1,0 +1,158 @@
+// src/controllers/queueController.js
+const { getQueues, getQueue } = require('../queues');
+
+// GET /queues/stats
+const getQueueStats = async (req, res) => {
+  try {
+    const queues = getQueues();
+    const stats = await Promise.all(
+      Object.entries(queues).map(async ([name, queue]) => {
+        const [jobCounts, isPaused] = await Promise.all([queue.getJobCounts(), queue.isPaused()]);
+        return {
+          name,
+          isPaused,
+          counts: {
+            waiting: jobCounts.waiting,
+            active: jobCounts.active,
+            completed: jobCounts.completed,
+            failed: jobCounts.failed,
+            delayed: jobCounts.delayed,
+            total:
+              jobCounts.waiting +
+              jobCounts.active +
+              jobCounts.completed +
+              jobCounts.failed +
+              jobCounts.delayed,
+          },
+        };
+      })
+    );
+    return res.status(200).json({ success: true, data: stats });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+// GET /queues/:name/jobs
+const getQueueJobs = async (req, res) => {
+  try {
+    const { name } = req.params;
+    const { status = 'waiting', start = 0, end = 49 } = req.query;
+
+    const queue = getQueue(name);
+    if (!queue) {
+      return res.status(404).json({ success: false, message: `Queue "${name}" not found` });
+    }
+
+    const validStatuses = ['waiting', 'active', 'completed', 'failed', 'delayed'];
+    if (!validStatuses.includes(status)) {
+      return res.status(400).json({
+        success: false,
+        message: `Invalid status. Use one of: ${validStatuses.join(', ')}`,
+      });
+    }
+
+    const jobs = await queue.getJobs([status], Number(start), Number(end));
+    const jobData = jobs.map(job => ({
+      id: job.id,
+      name: job.name,
+      data: job.data,
+      opts: job.opts,
+      status,
+      progress: job._progress,
+      attemptsMade: job.attemptsMade,
+      timestamp: job.timestamp,
+      processedOn: job.processedOn,
+      finishedOn: job.finishedOn,
+      processingTime: job.finishedOn && job.processedOn ? job.finishedOn - job.processedOn : null,
+    }));
+
+    return res.status(200).json({ success: true, count: jobData.length, data: jobData });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+// GET /queues/:name/failed
+const getFailedJobs = async (req, res) => {
+  try {
+    const { name } = req.params;
+    const { start = 0, end = 49 } = req.query;
+
+    const queue = getQueue(name);
+    if (!queue) {
+      return res.status(404).json({ success: false, message: `Queue "${name}" not found` });
+    }
+
+    const jobs = await queue.getFailed(Number(start), Number(end));
+    const jobData = jobs.map(job => ({
+      id: job.id,
+      name: job.name,
+      data: job.data,
+      failedReason: job.failedReason,
+      stacktrace: job.stacktrace,
+      attemptsMade: job.attemptsMade,
+      timestamp: job.timestamp,
+      processedOn: job.processedOn,
+      finishedOn: job.finishedOn,
+    }));
+
+    return res.status(200).json({ success: true, count: jobData.length, data: jobData });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+// POST /queues/:name/jobs/:id/retry
+const retryJob = async (req, res) => {
+  try {
+    const { name, id } = req.params;
+
+    const queue = getQueue(name);
+    if (!queue) {
+      return res.status(404).json({ success: false, message: `Queue "${name}" not found` });
+    }
+
+    const job = await queue.getJob(id);
+    if (!job) {
+      return res
+        .status(404)
+        .json({ success: false, message: `Job "${id}" not found in queue "${name}"` });
+    }
+
+    await job.retry();
+    return res
+      .status(200)
+      .json({ success: true, message: `Job "${id}" has been queued for retry` });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+// DELETE /queues/:name/jobs/:id/remove
+const removeJob = async (req, res) => {
+  try {
+    const { name, id } = req.params;
+
+    const queue = getQueue(name);
+    if (!queue) {
+      return res.status(404).json({ success: false, message: `Queue "${name}" not found` });
+    }
+
+    const job = await queue.getJob(id);
+    if (!job) {
+      return res
+        .status(404)
+        .json({ success: false, message: `Job "${id}" not found in queue "${name}"` });
+    }
+
+    await job.remove();
+    return res
+      .status(200)
+      .json({ success: true, message: `Job "${id}" has been removed from queue "${name}"` });
+  } catch (error) {
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+module.exports = { getQueueStats, getQueueJobs, getFailedJobs, retryJob, removeJob };

--- a/src/middleware/adminAuth.js
+++ b/src/middleware/adminAuth.js
@@ -1,0 +1,11 @@
+// src/middlewares/adminAuth.js
+const adminAuth = (req, res, next) => {
+  // Adapt this to match however the project handles admin auth
+  // e.g., check req.user.role from a JWT middleware already in the pipeline
+  if (!req.user || req.user.role !== 'admin') {
+    return res.status(403).json({ message: 'Admin access required' });
+  }
+  next();
+};
+
+module.exports = adminAuth;

--- a/src/queues/index.js
+++ b/src/queues/index.js
@@ -1,0 +1,26 @@
+// src/queues/index.js
+const Bull = require('bull');
+
+const queues = {};
+
+/**
+ * Register a queue by name. Call this wherever you create queues.
+ */
+const registerQueue = (name, redisConfig) => {
+  if (!queues[name]) {
+    queues[name] = new Bull(name, { redis: redisConfig });
+  }
+  return queues[name];
+};
+
+/**
+ * Get all registered queues
+ */
+const getQueues = () => queues;
+
+/**
+ * Get a single queue by name
+ */
+const getQueue = (name) => queues[name] || null;
+
+module.exports = { registerQueue, getQueues, getQueue };

--- a/src/routes/jobRoutes.js
+++ b/src/routes/jobRoutes.js
@@ -87,3 +87,14 @@ router.get('/stats', async (req, res) => {
 });
 
 export default router;
+const { registerQueue } = require('../queues');
+
+// Example — wrap existing queue creation
+const emailQueue = registerQueue('email', {
+  host: process.env.REDIS_HOST,
+  port: process.env.REDIS_PORT,
+});
+const notificationQueue = registerQueue('notification', {
+  host: process.env.REDIS_HOST,
+  port: process.env.REDIS_PORT,
+});

--- a/src/routes/queueRoutes.js
+++ b/src/routes/queueRoutes.js
@@ -1,0 +1,22 @@
+// src/routes/queueRoutes.js
+const express = require('express');
+const router = express.Router();
+const {
+  getQueueStats,
+  getQueueJobs,
+  getFailedJobs,
+  retryJob,
+  removeJob,
+} = require('../controllers/queueController');
+const adminAuth = require('../middlewares/adminAuth');
+
+// Apply admin protection to all queue routes
+router.use(adminAuth);
+
+router.get('/stats', getQueueStats);
+router.get('/:name/jobs', getQueueJobs);
+router.get('/:name/failed', getFailedJobs);
+router.post('/:name/jobs/:id/retry', retryJob);
+router.delete('/:name/jobs/:id/remove', removeJob);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -62,3 +62,7 @@ async function init() {
 }
 
 init();
+const queueRoutes = require('./routes/queueRoutes');
+
+// Mount under /queues
+app.use('/queues', queueRoutes);


### PR DESCRIPTION
feat: Add Queue Monitoring Dashboard API Endpoints
This PR implements admin-protected REST endpoints to expose Bull queue statistics for monitoring dashboards.
Changes:

GET /queues/stats—returns aggregated job counts (total, active, waiting, failed, delayed) across all queues
GET /queues/:name/jobs—lists jobs in a queue filtered by status with pagination
GET /queues/:name/failed—lists failed jobs with error messages and stack traces
POST /queues/:name/jobs/:id/retry — manually retries a failed job
DELETE /queues/:name/jobs/:id/remove — removes a job from a queue

All endpoints are protected by admin authentication middleware.
Closes #144 