### PR TITLE
test: Re-enable skipped auth verify email success test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3153,24 +3153,6 @@
         }
       }
     },
-    "node_modules/@nestjs-modules/ioredis/node_modules/@nestjs/typeorm": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-10.0.2.tgz",
-      "integrity": "sha512-H738bJyydK4SQkRCTeh1aFBxoO1E9xdL/HaLGThwrqN95os5mEyAtK7BLADOS+vldP4jDZ2VQPLj4epWwRqCeQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "uuid": "9.0.1"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "reflect-metadata": "^0.1.13 || ^0.2.0",
-        "rxjs": "^7.2.0",
-        "typeorm": "^0.3.0"
-      }
-    },
     "node_modules/@nestjs-modules/ioredis/node_modules/reflect-metadata": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
@@ -3178,20 +3160,6 @@
       "license": "Apache-2.0",
       "optional": true,
       "peer": true
-    },
-    "node_modules/@nestjs-modules/ioredis/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/@nestjs/bull": {
       "version": "11.0.4",
@@ -15156,27 +15124,10 @@
             "check-disk-space": "3.4.0"
           }
         },
-        "@nestjs/typeorm": {
-          "version": "10.0.2",
-          "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-10.0.2.tgz",
-          "integrity": "sha512-H738bJyydK4SQkRCTeh1aFBxoO1E9xdL/HaLGThwrqN95os5mEyAtK7BLADOS+vldP4jDZ2VQPLj4epWwRqCeQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "uuid": "9.0.1"
-          }
-        },
         "reflect-metadata": {
           "version": "0.1.14",
           "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
           "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-          "optional": true,
-          "peer": true
-        },
-        "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
           "optional": true,
           "peer": true
         }

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -28,6 +28,12 @@ describe('AuthService', () => {
     findByEmail: jest.fn(),
     findById: jest.fn(),
     create: jest.fn(),
+    // usersRepository is accessed directly in AuthService.verifyEmail
+    usersRepository: {
+      findOne: jest.fn(),
+    },
+    // save is called to persist the updated user
+    save: jest.fn(),
   };
   const mockJwtService = {
     sign: jest.fn(),
@@ -65,11 +71,11 @@ describe('AuthService', () => {
     const userId = 'user-id';
     const tokenId = 'token-id';
     const refreshToken = 'valid-refresh-token';
-    const user = { 
-      id: userId, 
-      email: 'test@example.com', 
+    const user = {
+      id: userId,
+      email: 'test@example.com',
       role: Role.USER,
-      phoneNumber: '+1234567890'
+      phoneNumber: '+1234567890',
     };
 
     beforeEach(() => {
@@ -77,24 +83,29 @@ describe('AuthService', () => {
     });
 
     it('should successfully refresh tokens with valid refresh token', async () => {
-      const payload = { sub: userId, tokenId, role: Role.USER, email: user.email };
+      const payload = {
+        sub: userId,
+        tokenId,
+        role: Role.USER,
+        email: user.email,
+      };
       const newAccessToken = 'new-access-token';
       const newRefreshToken = 'new-refresh-token';
 
       // Mock JWT verification
       mockJwtService.verify.mockReturnValue(payload);
-      
+
       // Mock Redis - token exists
       mockRedisClient.get.mockResolvedValue(refreshToken);
-      
+
       // Mock user lookup
       mockUsersService.findById.mockResolvedValue(user);
-      
+
       // Mock JWT signing for new tokens
       mockJwtService.sign
         .mockReturnValueOnce(newAccessToken)
         .mockReturnValueOnce(newRefreshToken);
-      
+
       // Mock Redis delete and set
       mockRedisClient.del.mockResolvedValue(1);
       mockRedisClient.set.mockResolvedValue('OK');
@@ -103,23 +114,23 @@ describe('AuthService', () => {
 
       // Verify JWT was verified
       expect(mockJwtService.verify).toHaveBeenCalledWith(refreshToken);
-      
+
       // Verify old token was retrieved from Redis
       expect(mockRedisClient.get).toHaveBeenCalledWith(
         `refresh:${userId}:${tokenId}`,
       );
-      
+
       // Verify old token was invalidated (deleted)
       expect(mockRedisClient.del).toHaveBeenCalledWith(
         `refresh:${userId}:${tokenId}`,
       );
-      
+
       // Verify user was looked up
       expect(mockUsersService.findById).toHaveBeenCalledWith(userId);
-      
+
       // Verify new tokens were generated
       expect(mockJwtService.sign).toHaveBeenCalledTimes(2);
-      
+
       // Verify result contains new tokens
       expect(result).toEqual({
         accessToken: newAccessToken,
@@ -128,7 +139,12 @@ describe('AuthService', () => {
     });
 
     it('should verify the payload content of the new access token', async () => {
-      const payload = { sub: userId, tokenId, role: Role.USER, email: user.email };
+      const payload = {
+        sub: userId,
+        tokenId,
+        role: Role.USER,
+        email: user.email,
+      };
       const newAccessToken = 'new-access-token';
       const newRefreshToken = 'new-refresh-token';
 
@@ -145,14 +161,14 @@ describe('AuthService', () => {
 
       // Verify the new access token contains correct payload
       expect(mockJwtService.sign).toHaveBeenCalledWith(
-        { 
-          sub: userId, 
-          email: user.email, 
-          role: Role.USER 
+        {
+          sub: userId,
+          email: user.email,
+          role: Role.USER,
         },
-        { expiresIn: '15m' }
+        { expiresIn: '15m' },
       );
-      
+
       // Verify the new refresh token contains tokenId for rotation
       expect(mockJwtService.sign).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -161,7 +177,7 @@ describe('AuthService', () => {
           role: Role.USER,
           tokenId: expect.any(String),
         }),
-        { expiresIn: '7d' }
+        { expiresIn: '7d' },
       );
     });
 
@@ -184,7 +200,7 @@ describe('AuthService', () => {
       // Verify the order: get token, then delete it (rotation)
       const callOrder = mockRedisClient.get.mock.invocationCallOrder[0];
       const deleteOrder = mockRedisClient.del.mock.invocationCallOrder[0];
-      
+
       expect(deleteOrder).toBeGreaterThan(callOrder);
       expect(mockRedisClient.del).toHaveBeenCalledWith(
         `refresh:${userId}:${tokenId}`,
@@ -280,7 +296,7 @@ describe('AuthService', () => {
           reason: 'Invalid or reused refresh token',
         },
       );
-      
+
       // Verify all user sessions were cleared
       expect(mockRedisClient.keys).toHaveBeenCalledWith(`refresh:${userId}:*`);
       expect(mockRedisClient.del).toHaveBeenCalledWith([
@@ -322,6 +338,56 @@ describe('AuthService', () => {
       });
 
       await expect(service.logout('invalid')).resolves.not.toThrow();
+    });
+  });
+
+  describe('verifyEmail', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should verify email successfully', async () => {
+      const token = 'verify-token-123';
+      const user = {
+        id: 'user-id-verify',
+        email: 'verify@example.com',
+        emailVerificationToken: token,
+        emailVerificationExpiry: new Date(Date.now() + 10000),
+        isVerified: false,
+      } as any;
+
+      // Mock repository lookup and save
+      mockUsersService.usersRepository.findOne.mockResolvedValue(user);
+
+      let savedUser: any = null;
+      mockUsersService.save.mockImplementation(async (u: any) => {
+        savedUser = u;
+        return u;
+      });
+
+      const result = await service.verifyEmail({ token } as any);
+
+      // Ensure findOne was called for the verification token
+      expect(mockUsersService.usersRepository.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            emailVerificationToken: token,
+          }),
+        }),
+      );
+
+      // Service should return success message
+      expect(result).toEqual({ message: 'Email verified successfully' });
+
+      // Ensure save was called and the user was marked verified and tokens cleared
+      expect(mockUsersService.save).toHaveBeenCalled();
+      expect(savedUser).toEqual(
+        expect.objectContaining({
+          isVerified: true,
+          emailVerificationToken: null,
+          emailVerificationExpiry: null,
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
Closes #351 

Changes I made:
- Re-enabled email verification success test in auth.service.spec.ts (removed skip)
- Added local mocks for usersRepository.findOne and usersService.save to return/capture user
- Asserted token lookup, service response, and DB changes (isVerified = true; token/expiry cleared)
- No real emails sent, mocks kept localized to the spec file

Screenshot:
<img width="945" height="547" alt="image" src="https://github.com/user-attachments/assets/c6553b0c-858a-491d-9d77-2a5d1f42cd4f" />
