### PR TITLE
feat(health): add redis health check

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -9,9 +9,4 @@ export class AppController {
   getHello(): string {
     return this.appService.getHello();
   }
-
-  @Get('health')
-  getHealth(): { status: string } {
-    return { status: 'ok' };
-  }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { TasksModule } from './tasks/tasks.module';
 import { TaskAssignmentModule } from './tasks/assignment/task-assignment.module';
 import { RewardModule } from './rewards/reward.module';
 import { StorageModule } from './storage/storage.module';
+import { HealthModule } from './health/health.module';
 
 @Module({
   imports: [
@@ -64,6 +65,7 @@ import { StorageModule } from './storage/storage.module';
     TaskAssignmentModule,
     RewardModule,
     StorageModule,
+    HealthModule,
   ],
   controllers: [AppController],
   providers: [AppService, ShutdownService],

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -1,91 +1,62 @@
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
+import { HealthCheckError } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
 
 describe('HealthController', () => {
   let controller: HealthController;
-  const mockHealth = {} as any;
+  let db: { pingCheck: jest.Mock };
+  let redis: { isHealthy: jest.Mock };
 
-  const makeController = (dbMock: any, redisMock: any) => {
-    return new HealthController(mockHealth, dbMock, redisMock as any);
-  };
+  const makeController = () => new HealthController(db as any, redis as any);
+
+  beforeEach(() => {
+    db = {
+      pingCheck: jest.fn().mockResolvedValue({ db: { status: 'up' } }),
+    };
+
+    redis = {
+      isHealthy: jest.fn().mockResolvedValue({ redis: { status: 'up', responseTime: 4 } }),
+    };
+
+    controller = makeController();
+  });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
-  it('all services healthy -> returns 200 with statuses up', async () => {
-    const db = { pingCheck: jest.fn().mockResolvedValueOnce({ database: { status: 'up' } }) };
-    const redis = { ping: jest.fn().mockResolvedValueOnce('PONG') };
+  it('returns top-level dependency statuses when services are healthy', async () => {
+    const response = await controller.check();
 
-    controller = makeController(db, redis);
-
-    const res = await controller.check();
-
-    expect(db.pingCheck).toHaveBeenCalledWith('database');
-    expect(redis.ping).toHaveBeenCalled();
-    expect(res).toEqual({ status: 'ok', db: 'up', redis: 'up' });
+    expect(db.pingCheck).toHaveBeenCalledWith('db');
+    expect(redis.isHealthy).toHaveBeenCalledWith('redis');
+    expect(response).toEqual({
+      status: 'ok',
+      db: { status: 'up' },
+      redis: { status: 'up', responseTime: 4 },
+    });
   });
 
-  it('database unreachable -> throws 503 with database down', async () => {
-    const db = { pingCheck: jest.fn().mockRejectedValueOnce(new Error('db down')) };
-    const redis = { ping: jest.fn().mockResolvedValueOnce('PONG') };
+  it('logs at error level and rethrows when a health check fails', async () => {
+    redis.isHealthy.mockRejectedValueOnce(
+      new HealthCheckError('Redis unavailable', {
+        redis: { status: 'down', responseTime: 9 },
+      }),
+    );
 
-    controller = makeController(db, redis);
+    const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
 
-    try {
-      await controller.check();
-      throw new Error('Expected HttpException');
-    } catch (err) {
-      expect(err).toBeInstanceOf(HttpException);
-      expect((err as HttpException).getStatus()).toBe(HttpStatus.SERVICE_UNAVAILABLE);
-      expect((err as HttpException).getResponse()).toEqual({ status: 'error', db: 'down', redis: 'up' });
-    }
-  });
+    await expect(controller.check()).rejects.toMatchObject({
+      response: {
+        status: 'error',
+        db: { status: 'up' },
+        redis: { status: 'down', responseTime: 9 },
+      },
+      status: 503,
+    });
 
-  it('redis unreachable -> throws 503 with redis down', async () => {
-    const db = { pingCheck: jest.fn().mockResolvedValueOnce({ database: { status: 'up' } }) };
-    const redis = { ping: jest.fn().mockRejectedValueOnce(new Error('redis down')) };
-
-    controller = makeController(db, redis);
-
-    try {
-      await controller.check();
-      throw new Error('Expected HttpException');
-    } catch (err) {
-      expect(err).toBeInstanceOf(HttpException);
-      expect((err as HttpException).getStatus()).toBe(HttpStatus.SERVICE_UNAVAILABLE);
-      expect((err as HttpException).getResponse()).toEqual({ status: 'error', db: 'up', redis: 'down' });
-    }
-  });
-
-  it('multiple services down -> throws 503 with both down', async () => {
-    const db = { pingCheck: jest.fn().mockRejectedValueOnce(new Error('db down')) };
-    const redis = { ping: jest.fn().mockRejectedValueOnce(new Error('redis down')) };
-
-    controller = makeController(db, redis);
-
-    try {
-      await controller.check();
-      throw new Error('Expected HttpException');
-    } catch (err) {
-      expect(err).toBeInstanceOf(HttpException);
-      expect((err as HttpException).getStatus()).toBe(HttpStatus.SERVICE_UNAVAILABLE);
-      expect((err as HttpException).getResponse()).toEqual({ status: 'error', db: 'down', redis: 'down' });
-    }
-  });
-
-  it('response shape matches expected DTO for healthy', async () => {
-    const db = { pingCheck: jest.fn().mockResolvedValueOnce({ database: { status: 'up' } }) };
-    const redis = { ping: jest.fn().mockResolvedValueOnce('PONG') };
-
-    controller = makeController(db, redis);
-
-    const res = await controller.check();
-    expect(res).toHaveProperty('status');
-    expect(res).toHaveProperty('db');
-    expect(res).toHaveProperty('redis');
-    expect(typeof res.status).toBe('string');
-    expect(typeof res.db).toBe('string');
-    expect(typeof res.redis).toBe('string');
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Health check failed: {"status":"error","db":{"status":"up"},"redis":{"status":"down","responseTime":9}}',
+    );
   });
 });

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,48 +1,61 @@
-import { Controller, Get, HttpException, HttpStatus } from '@nestjs/common';
-import { HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
-import { InjectRedis } from '@nestjs-modules/ioredis';
-import Redis from 'ioredis';
+import { Controller, Get, Logger, ServiceUnavailableException } from '@nestjs/common';
+import {
+  HealthCheckError,
+  TypeOrmHealthIndicator,
+} from '@nestjs/terminus';
+import { RedisHealthIndicator } from './redis-health.indicator';
 
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
   constructor(
-    private health: HealthCheckService,
-    private db: TypeOrmHealthIndicator,
-    @InjectRedis() private readonly redis: Redis,
+    private readonly db: TypeOrmHealthIndicator,
+    private readonly redis: RedisHealthIndicator,
   ) {}
 
   @Get()
   async check() {
-    let dbStatus = 'up';
-    let redisStatus = 'up';
+    const details: Record<string, unknown> = {};
+    let hasFailure = false;
 
     try {
-      await this.db.pingCheck('database');
-    } catch {
-      dbStatus = 'down';
+      Object.assign(details, await this.db.pingCheck('db'));
+    } catch (error) {
+      hasFailure = true;
+      details.db =
+        error instanceof HealthCheckError
+          ? error.causes.db
+          : {
+              status: 'down',
+            };
     }
 
     try {
-      await this.redis.ping();
-    } catch {
-      redisStatus = 'down';
+      Object.assign(details, await this.redis.isHealthy('redis'));
+    } catch (error) {
+      hasFailure = true;
+      details.redis =
+        error instanceof HealthCheckError
+          ? error.causes.redis
+          : {
+              status: 'down',
+            };
     }
 
-    if (dbStatus === 'down' || redisStatus === 'down') {
-      throw new HttpException(
-        {
-          status: 'error',
-          db: dbStatus,
-          redis: redisStatus,
-        },
-        HttpStatus.SERVICE_UNAVAILABLE,
-      );
+    if (hasFailure) {
+      const payload = {
+        status: 'error',
+        ...details,
+      };
+
+      this.logger.error(`Health check failed: ${JSON.stringify(payload)}`);
+      throw new ServiceUnavailableException(payload);
     }
 
     return {
       status: 'ok',
-      db: dbStatus,
-      redis: redisStatus,
+      ...details,
     };
   }
 }

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
+import { RedisHealthIndicator } from './redis-health.indicator';
 
 @Module({
   imports: [TerminusModule],
   controllers: [HealthController],
+  providers: [RedisHealthIndicator],
 })
 export class HealthModule {}

--- a/src/health/redis-health.indicator.spec.ts
+++ b/src/health/redis-health.indicator.spec.ts
@@ -1,0 +1,33 @@
+import { HealthCheckError } from '@nestjs/terminus';
+import { RedisHealthIndicator } from './redis-health.indicator';
+
+describe('RedisHealthIndicator', () => {
+  it('returns redis up with response time when redis is reachable', async () => {
+    const redis = {
+      ping: jest.fn().mockResolvedValue('PONG'),
+    };
+
+    const indicator = new RedisHealthIndicator(redis as any);
+    const result = await indicator.isHealthy('redis');
+
+    expect(redis.ping).toHaveBeenCalledTimes(1);
+    expect(result.redis.status).toBe('up');
+    expect(typeof result.redis.responseTime).toBe('number');
+  });
+
+  it('throws HealthCheckError with redis down when redis is unreachable', async () => {
+    const redis = {
+      ping: jest.fn().mockRejectedValue(new Error('redis down')),
+    };
+
+    const indicator = new RedisHealthIndicator(redis as any);
+
+    await expect(indicator.isHealthy('redis')).rejects.toMatchObject({
+      causes: {
+        redis: {
+          status: 'down',
+        },
+      },
+    } satisfies Partial<HealthCheckError>);
+  });
+});

--- a/src/health/redis-health.indicator.ts
+++ b/src/health/redis-health.indicator.ts
@@ -1,0 +1,42 @@
+import { InjectRedis } from '@nestjs-modules/ioredis';
+import { Injectable } from '@nestjs/common';
+import { HealthCheckError, HealthIndicatorResult } from '@nestjs/terminus';
+import Redis from 'ioredis';
+import { performance } from 'node:perf_hooks';
+
+type RedisStatus = {
+  status: 'up' | 'down';
+  responseTime: number;
+};
+
+@Injectable()
+export class RedisHealthIndicator {
+  constructor(@InjectRedis() private readonly redis: Redis) {}
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const start = performance.now();
+
+    try {
+      await this.redis.ping();
+
+      return {
+        [key]: {
+          status: 'up',
+          responseTime: Math.round(performance.now() - start),
+        } satisfies RedisStatus,
+      };
+    } catch (error) {
+      const result = {
+        [key]: {
+          status: 'down',
+          responseTime: Math.round(performance.now() - start),
+        } satisfies RedisStatus,
+      };
+
+      throw new HealthCheckError(
+        error instanceof Error ? error.message : 'Redis health check failed',
+        result,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Overview
This PR adds Redis health monitoring to the existing `/health` endpoint so Redis outages are surfaced immediately instead of failing silently. The endpoint now reports Redis availability, includes Redis response time in milliseconds, and returns HTTP 503 when Redis is unreachable.

## Related Issue
Closes #393

## Changes

### ⚙️ Health Endpoint
- **[MODIFY]** `src/health/health.controller.ts`
  - Replaced the manual string-only Redis status handling with a structured health response.
  - Added Redis status to the top-level `/health` response.
  - Returns `503 Service Unavailable` with `redis: { status: "down" }` when Redis cannot be reached.
  - Logs health check failures at error level.

- **[MODIFY]** `src/app.controller.ts`
  - Removed the placeholder `/health` route so the dedicated health controller is the only authoritative implementation.

### 🧩 Redis Health Indicator
- **[ADD]** `src/health/redis-health.indicator.ts`
  - Added a custom Redis health indicator using the existing Redis connection.
  - Uses Redis `PING` to verify connectivity.
  - Includes Redis response time in milliseconds in the health payload.
  - Throws a Terminus-compatible health error when Redis is down.

### 🏗️ Module Wiring
- **[MODIFY]** `src/health/health.module.ts`
  - Registered the new `RedisHealthIndicator` provider.

- **[MODIFY]** `src/app.module.ts`
  - Imported `HealthModule` so the dedicated health endpoint is active in the application.

### ✅ Tests
- **[MODIFY]** `src/health/health.controller.spec.ts`
  - Updated tests to cover the new top-level health response shape.
  - Added coverage for error logging and 503 responses.

- **[ADD]** `src/health/redis-health.indicator.spec.ts`
  - Added tests for Redis-up and Redis-down indicator behavior.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| `GET /health` response includes a `redis` status key | ✅ |
| Returns `{ redis: { status: "up" } }` when Redis is reachable | ✅ |
| Returns HTTP 503 and `{ redis: { status: "down" } }` when Redis is unreachable | ✅ |
| Response includes Redis response time in milliseconds | ✅ |
| Health check failures are logged at error level | ✅ |

## How to Test

```bash
# 1. Confirm you're on the branch
git branch --show-current

# 2. Install dependencies if needed
npm install

# 3. Start the app
npm run start:dev

# 4. Check the health endpoint while Redis is running
curl http://localhost:3000/health

# 5. Stop Redis and check again
curl http://localhost:3000/health

# 6. Optional: run the targeted tests
npm test -- src/health/health.controller.spec.ts src/health/redis-health.indicator.spec.ts --runInBand

# 7. Optional: verify the project still builds
npm run build
```