### PR TITLE
feat(rewards): implement Dead Letter Queue for failed reward jobs

### DIFF
--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -9,10 +9,24 @@ import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 import { TasksScheduler } from '../tasks/tasks.scheduler';
 import { TaskAssignmentModule } from '../tasks/assignment/task-assignment.module';
+import { FailedRewardJobController } from './rewards/failed-reward-job.controller';
+import { FailedRewardJobService } from './rewards/failed-reward-job.service';
+import { RewardModule } from '../rewards/reward.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), AuditModule, TaskAssignmentModule],
-  controllers: [AdminUsersController, AdminController],
-  providers: [AdminUsersService, UsersService, AdminService, TasksScheduler],
+  imports: [
+    TypeOrmModule.forFeature([User]),
+    AuditModule,
+    TaskAssignmentModule,
+    RewardModule,
+  ],
+  controllers: [AdminUsersController, AdminController, FailedRewardJobController],
+  providers: [
+    AdminUsersService,
+    UsersService,
+    AdminService,
+    TasksScheduler,
+    FailedRewardJobService,
+  ],
 })
 export class AdminModule {}

--- a/src/admin/rewards/dto/failed-reward-job.dto.ts
+++ b/src/admin/rewards/dto/failed-reward-job.dto.ts
@@ -1,0 +1,77 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ListFailedJobsDto {
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}
+
+export class FailedRewardJobResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  userId: string;
+
+  @ApiProperty()
+  xlmAmount: number;
+
+  @ApiPropertyOptional()
+  taskCompletionId?: string;
+
+  @ApiProperty()
+  errorMessage: string;
+
+  @ApiPropertyOptional()
+  jobId?: string;
+
+  @ApiProperty()
+  attemptsMade: number;
+
+  @ApiProperty()
+  jobType: string;
+
+  @ApiProperty()
+  failedAt: Date;
+}
+
+export class ListFailedJobsResponseDto {
+  @ApiProperty({ type: [FailedRewardJobResponseDto] })
+  data: FailedRewardJobResponseDto[];
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  totalPages: number;
+}
+
+export class ReplayFailedJobResponseDto {
+  @ApiProperty()
+  success: boolean;
+
+  @ApiProperty()
+  message: string;
+
+  @ApiPropertyOptional()
+  replayedJobId?: string;
+}

--- a/src/admin/rewards/failed-reward-job.controller.ts
+++ b/src/admin/rewards/failed-reward-job.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiSecurity,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { Role } from '../../auth/enums/role.enum';
+import { FailedRewardJobService } from './failed-reward-job.service';
+import {
+  ListFailedJobsDto,
+  ListFailedJobsResponseDto,
+  ReplayFailedJobResponseDto,
+} from './dto/failed-reward-job.dto';
+
+@ApiTags('Admin - Reward Management')
+@ApiBearerAuth()
+@ApiSecurity('bearer')
+@Controller('admin/rewards')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN)
+export class FailedRewardJobController {
+  constructor(private readonly failedRewardJobService: FailedRewardJobService) {}
+
+  @Get('failed')
+  @ApiOperation({
+    summary: 'List all failed reward jobs',
+    description:
+      'Returns a paginated list of reward jobs that failed after exhausting all retry attempts.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of failed jobs',
+    type: ListFailedJobsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  async listFailedJobs(
+    @Query() query: ListFailedJobsDto,
+  ): Promise<ListFailedJobsResponseDto> {
+    return this.failedRewardJobService.listFailedJobs(query);
+  }
+
+  @Post('failed/:id/replay')
+  @ApiOperation({
+    summary: 'Replay a failed reward job',
+    description:
+      'Re-queues a specific failed job for processing. The job is removed from the failed jobs table and added back to the reward queue.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Failed job successfully re-queued',
+    type: ReplayFailedJobResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'Failed job not found' })
+  async replayFailedJob(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<ReplayFailedJobResponseDto> {
+    return this.failedRewardJobService.replayFailedJob(id);
+  }
+}

--- a/src/admin/rewards/failed-reward-job.service.ts
+++ b/src/admin/rewards/failed-reward-job.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FailedRewardJob } from '../../rewards/entities/failed-reward-job.entity';
+import { DeadLetterProcessor } from '../../rewards/queues/dead-letter.processor';
+import {
+  ListFailedJobsDto,
+  ListFailedJobsResponseDto,
+  ReplayFailedJobResponseDto,
+} from './dto/failed-reward-job.dto';
+
+@Injectable()
+export class FailedRewardJobService {
+  private readonly logger = new Logger(FailedRewardJobService.name);
+
+  constructor(
+    @InjectRepository(FailedRewardJob)
+    private readonly failedRewardJobRepository: Repository<FailedRewardJob>,
+    private readonly deadLetterProcessor: DeadLetterProcessor,
+  ) {}
+
+  /**
+   * Get paginated list of failed reward jobs for admin review.
+   */
+  async listFailedJobs(
+    query: ListFailedJobsDto,
+  ): Promise<ListFailedJobsResponseDto> {
+    const { page = 1, limit = 20 } = query;
+    const skip = (page - 1) * limit;
+
+    const [jobs, total] = await this.failedRewardJobRepository.findAndCount({
+      order: { failedAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return {
+      data: jobs.map((job) => ({
+        id: job.id,
+        userId: job.userId,
+        xlmAmount: job.xlmAmount,
+        taskCompletionId: job.taskCompletionId,
+        errorMessage: job.errorMessage,
+        jobId: job.jobId,
+        attemptsMade: job.attemptsMade,
+        jobType: job.jobType,
+        failedAt: job.failedAt,
+      })),
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  /**
+   * Replay a specific failed job by re-queuing it.
+   */
+  async replayFailedJob(
+    failedJobId: string,
+  ): Promise<ReplayFailedJobResponseDto> {
+    const failedJob = await this.failedRewardJobRepository.findOne({
+      where: { id: failedJobId },
+    });
+
+    if (!failedJob) {
+      throw new NotFoundException(
+        `Failed reward job with ID ${failedJobId} not found`,
+      );
+    }
+
+    try {
+      const { jobId } = await this.deadLetterProcessor.replayFailedJob(
+        failedJobId,
+      );
+
+      return {
+        success: true,
+        message: `Failed job ${failedJobId} has been re-queued successfully.`,
+        replayedJobId: jobId,
+      };
+    } catch (error) {
+      this.logger.error(`Failed to replay job ${failedJobId}: ${error}`);
+      return {
+        success: false,
+        message: `Failed to replay job: ${error.message || String(error)}`,
+      };
+    }
+  }
+}

--- a/src/migrations/1740681600000-FailedRewardJobsTable.ts
+++ b/src/migrations/1740681600000-FailedRewardJobsTable.ts
@@ -1,0 +1,95 @@
+import { MigrationInterface, QueryRunner, Table, TableColumn, TableForeignKey } from 'typeorm';
+
+export class FailedRewardJobsTable1740681600000 implements MigrationInterface {
+  name = 'FailedRewardJobsTable1740681600000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const tableExists = await queryRunner.hasTable('failed_reward_jobs');
+
+    if (tableExists) {
+      return;
+    }
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'failed_reward_jobs',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'gen_random_uuid()',
+          },
+          {
+            name: 'userId',
+            type: 'uuid',
+          },
+          {
+            name: 'xlmAmount',
+            type: 'decimal',
+            precision: 10,
+            scale: 2,
+            default: 0,
+          },
+          {
+            name: 'taskCompletionId',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'errorMessage',
+            type: 'text',
+          },
+          {
+            name: 'jobId',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'attemptsMade',
+            type: 'int',
+            default: 0,
+          },
+          {
+            name: 'jobType',
+            type: 'varchar',
+            length: '50',
+            default: "'reward-distribution'",
+          },
+          {
+            name: 'jobData',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'failedAt',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+    );
+
+    // Foreign key to users table
+    await queryRunner.createForeignKey(
+      'failed_reward_jobs',
+      new TableForeignKey({
+        columnNames: ['userId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('failed_reward_jobs', true);
+  }
+}

--- a/src/queue/queue.constants.ts
+++ b/src/queue/queue.constants.ts
@@ -11,6 +11,9 @@ export const PROOF_VERIFICATION_QUEUE = 'proof-verification-queue' as const;
 export const USER_ACTIVITY_QUEUE = 'user-activity-queue' as const;
 export const DATA_PROCESSING_QUEUE = 'data-processing-queue' as const;
 
+// Dead Letter Queue for failed reward jobs
+export const REWARD_DEAD_LETTER_QUEUE = 'reward-dead-letter-queue' as const;
+
 // Queue Job Types for Reward Queue
 export const REWARD_DISTRIBUTION_JOB = 'reward-distribution' as const;
 export const REWARD_CALCULATION_JOB = 'reward-calculation' as const;
@@ -34,7 +37,8 @@ export type QueueName =
   | typeof TASK_VERIFICATION_QUEUE
   | typeof PROOF_VERIFICATION_QUEUE
   | typeof USER_ACTIVITY_QUEUE
-  | typeof DATA_PROCESSING_QUEUE;
+  | typeof DATA_PROCESSING_QUEUE
+  | typeof REWARD_DEAD_LETTER_QUEUE;
 
 export type RewardJobType =
   | typeof REWARD_DISTRIBUTION_JOB

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -9,6 +9,7 @@ import {
   PROOF_VERIFICATION_QUEUE,
   USER_ACTIVITY_QUEUE,
   DATA_PROCESSING_QUEUE,
+  REWARD_DEAD_LETTER_QUEUE,
 } from './queue.constants';
 
 @Module({
@@ -82,6 +83,10 @@ import {
         max: 25,
         duration: 1000,
       },
+    }),
+    // Dead Letter Queue for failed reward jobs - no limiter, all failed jobs go here
+    BullModule.registerQueue({
+      name: REWARD_DEAD_LETTER_QUEUE,
     }),
   ],
   exports: [BullModule],

--- a/src/rewards/entities/failed-reward-job.entity.ts
+++ b/src/rewards/entities/failed-reward-job.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('failed_reward_jobs')
+export class FailedRewardJob {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
+  xlmAmount: number;
+
+  @Column({ type: 'uuid', nullable: true })
+  taskCompletionId?: string;
+
+  @Column({ type: 'text' })
+  errorMessage: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  jobId?: string;
+
+  @Column({ type: 'int', default: 0 })
+  attemptsMade: number;
+
+  @Column({ type: 'varchar', length: 50, default: 'reward-distribution' })
+  jobType: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  jobData?: Record<string, unknown>;
+
+  @CreateDateColumn()
+  failedAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/rewards/queues/dead-letter.processor.ts
+++ b/src/rewards/queues/dead-letter.processor.ts
@@ -1,0 +1,111 @@
+import { Process, Processor, OnQueueCompleted } from '@nestjs/bull';
+import { Job } from 'bull';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import { REWARD_DEAD_LETTER_QUEUE, REWARD_QUEUE, REWARD_DISTRIBUTION_JOB } from '../../queue/queue.constants';
+import { FailedRewardJob } from '../entities/failed-reward-job.entity';
+
+export interface DeadLetterJobData {
+  userId: string;
+  xlmAmount: number;
+  taskCompletionId?: string;
+  errorMessage: string;
+  jobId?: string;
+  attemptsMade: number;
+  jobType: string;
+  jobData: Record<string, unknown>;
+}
+
+/**
+ * Dead Letter Queue Processor for failed reward jobs.
+ * Captures exhausted reward jobs so they can be investigated and replayed by admins.
+ */
+@Processor(REWARD_DEAD_LETTER_QUEUE)
+@Injectable()
+export class DeadLetterProcessor {
+  private readonly logger = new Logger(DeadLetterProcessor.name);
+
+  constructor(
+    @InjectRepository(FailedRewardJob)
+    private readonly failedRewardJobRepository: Repository<FailedRewardJob>,
+    @InjectQueue(REWARD_QUEUE) private readonly rewardQueue: Queue,
+  ) {}
+
+  /**
+   * Process a dead letter job - save to DB and log for admin review.
+   * Jobs arrive here when they exhaust all retry attempts in the reward queue.
+   */
+  @Process({ name: 'process', concurrency: 3 })
+  async handleDeadLetter(job: Job<DeadLetterJobData>) {
+    this.logger.warn(
+      `Processing dead letter job ${job.id} for completion ${job.data.taskCompletionId}`,
+    );
+
+    const { userId, xlmAmount, taskCompletionId, errorMessage, jobId, attemptsMade, jobType, jobData } = job.data;
+
+    // Save failed job to DB for admin review and replay
+    const failedJob = this.failedRewardJobRepository.create({
+      userId,
+      xlmAmount,
+      taskCompletionId,
+      errorMessage,
+      jobId: jobId || job.id?.toString(),
+      attemptsMade,
+      jobType,
+      jobData,
+    });
+
+    await this.failedRewardJobRepository.save(failedJob);
+
+    this.logger.error(
+      `Dead letter recorded for user ${userId}, completion ${taskCompletionId}: ${errorMessage}`,
+    );
+
+    return { success: true, failedJobId: failedJob.id };
+  }
+
+  /**
+   * Replay a specific failed job by re-adding it to the reward queue.
+   * After replay, the failed job record is removed.
+   */
+  async replayFailedJob(failedJobId: string): Promise<{ jobId: string }> {
+    const failedJob = await this.failedRewardJobRepository.findOne({
+      where: { id: failedJobId },
+    });
+
+    if (!failedJob) {
+      throw new Error(`Failed reward job ${failedJobId} not found`);
+    }
+
+    // Re-add to the reward queue
+    const replayJob = await this.rewardQueue.add(
+      REWARD_DISTRIBUTION_JOB,
+      {
+        completionId: failedJob.taskCompletionId,
+        userId: failedJob.userId,
+        xlmAmount: failedJob.xlmAmount,
+      },
+      {
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 1000,
+        },
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    );
+
+    // Delete from failed jobs after successful replay initiation
+    await this.failedRewardJobRepository.delete(failedJobId);
+
+    this.logger.log(
+      `Replayed failed job ${failedJobId} as ${replayJob.id}`,
+    );
+
+    return { jobId: replayJob.id?.toString() || '' };
+  }
+}

--- a/src/rewards/reward.module.ts
+++ b/src/rewards/reward.module.ts
@@ -3,16 +3,18 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { RewardController } from './reward.controller';
 import { RewardService } from './reward.service';
 import { RewardTransaction } from './entities/reward-transaction.entity';
+import { FailedRewardJob } from './entities/failed-reward-job.entity';
 import { TaskCompletion } from '../task-completion/entities/task-completion.entity';
 import { HealthTask } from '../entities/health-task.entity';
 import { CacheModule } from '@nestjs/cache-manager';
 import { BullModule } from '@nestjs/bull';
 import { RewardProcessor } from './reward.processor';
-import { REWARD_QUEUE } from '../queue/queue.constants';
+import { DeadLetterProcessor } from './queues/dead-letter.processor';
+import { REWARD_QUEUE, REWARD_DEAD_LETTER_QUEUE } from '../queue/queue.constants';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([RewardTransaction, TaskCompletion, HealthTask]),
+    TypeOrmModule.forFeature([RewardTransaction, FailedRewardJob, TaskCompletion, HealthTask]),
     CacheModule.register({
       ttl: 120, // 2 minutes default TTL
       isGlobal: false,
@@ -27,9 +29,13 @@ import { REWARD_QUEUE } from '../queue/queue.constants';
         },
       },
     }),
+    // Dead Letter Queue for failed reward jobs
+    BullModule.registerQueue({
+      name: REWARD_DEAD_LETTER_QUEUE,
+    }),
   ],
   controllers: [RewardController],
-  providers: [RewardService, RewardProcessor],
-  exports: [RewardService],
+  providers: [RewardService, RewardProcessor, DeadLetterProcessor],
+  exports: [RewardService, DeadLetterProcessor, TypeOrmModule],
 })
 export class RewardModule {}

--- a/src/rewards/reward.processor.ts
+++ b/src/rewards/reward.processor.ts
@@ -1,10 +1,13 @@
 import { Process, Processor, OnQueueFailed } from '@nestjs/bull';
 import { Job } from 'bull';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { Logger } from '@nestjs/common';
+import { Logger, Injectable } from '@nestjs/common';
 import {
   REWARD_QUEUE,
   REWARD_DISTRIBUTION_JOB,
+  REWARD_DEAD_LETTER_QUEUE,
 } from '../queue/queue.constants';
 import { RewardService } from './reward.service';
 
@@ -14,13 +17,27 @@ interface RewardJobData {
   xlmAmount: number;
 }
 
+interface DeadLetterJobData {
+  userId: string;
+  xlmAmount: number;
+  taskCompletionId?: string;
+  errorMessage: string;
+  jobId?: string;
+  attemptsMade: number;
+  jobType: string;
+  jobData: Record<string, unknown>;
+}
+
 @Processor(REWARD_QUEUE)
+@Injectable()
 export class RewardProcessor {
   private readonly logger = new Logger(RewardProcessor.name);
 
   constructor(
     private readonly rewardService: RewardService,
     private readonly eventEmitter: EventEmitter2,
+    @InjectQueue(REWARD_QUEUE) private readonly rewardQueue: Queue,
+    @InjectQueue(REWARD_DEAD_LETTER_QUEUE) private readonly dlq: Queue<DeadLetterJobData>,
   ) {}
 
   @Process({ name: REWARD_DISTRIBUTION_JOB, concurrency: 5 })
@@ -35,19 +52,35 @@ export class RewardProcessor {
   @OnQueueFailed()
   async onFailed(job: Job<RewardJobData>, error: Error) {
     this.logger.error(
-      `Job ${job.id} failed: ${error.message}. Attemps made: ${job.attemptsMade}`,
+      `Job ${job.id} failed: ${error.message}. Attempts made: ${job.attemptsMade}`,
     );
 
-    // If we've reached max attempts limit
-    if (job.attemptsMade >= job.opts.attempts) {
+    // If we've reached max attempts limit, move to dead letter queue
+    if (job.attemptsMade >= (job.opts.attempts || 3)) {
       await this.rewardService.handleRewardFailure(job.data.completionId);
 
-      // Emit failure event explicitly after max retries
+      // Add to dead letter queue for persistence and admin review
+      await this.dlq.add('process', {
+        userId: job.data.userId,
+        xlmAmount: job.data.xlmAmount,
+        taskCompletionId: job.data.completionId,
+        errorMessage: error.message,
+        jobId: job.id?.toString(),
+        attemptsMade: job.attemptsMade,
+        jobType: REWARD_DISTRIBUTION_JOB,
+        jobData: job.data as Record<string, unknown>,
+      });
+
+      // Emit failure event for notification service
       this.eventEmitter.emit('reward.failed', {
         userId: job.data.userId,
         completionId: job.data.completionId,
         error: error.message,
       });
+
+      this.logger.warn(
+        `Job ${job.id} moved to dead letter queue after ${job.attemptsMade} attempts`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

Implements a **Dead Letter Queue (DLQ)** for failed reward jobs as described in issue #427.

### Changes

1. **src/queue/queue.constants.ts** - Added REWARD_DEAD_LETTER_QUEUE constant
2. **src/queue/queue.module.ts** - Registered the new DLQ in BullModule
3. **src/rewards/entities/failed-reward-job.entity.ts** - New TypeORM entity persisting failed job details (userId, xlmAmount, errorMessage, attemptsMade, etc.)
4. **src/rewards/queues/dead-letter.processor.ts** - New processor that listens to the DLQ and saves failed jobs to the DB; also exposes eplayFailedJob() method
5. **src/rewards/reward.processor.ts** - Updated onFailed handler: when a job exhausts all 3 retry attempts, it is now moved to the DLQ via dlq.add('process', {...})
6. **src/rewards/reward.module.ts** - Registers DeadLetterProcessor, imports FailedRewardJob entity, exports DeadLetterProcessor for use in AdminModule
7. **src/admin/rewards/failed-reward-job.controller.ts** - New controller with:
   - GET /admin/rewards/failed - List all failed jobs (paginated)
   - POST /admin/rewards/failed/:id/replay - Replay a failed job
8. **src/admin/rewards/failed-reward-job.service.ts** - Service layer for list/replay operations
9. **src/admin/rewards/dto/failed-reward-job.dto.ts** - DTOs with Swagger decorators
10. **src/admin/admin.module.ts** - Imports RewardModule, registers new controller and service
11. **src/migrations/1740681600000-FailedRewardJobsTable.ts** - Migration for ailed_reward_jobs table

### Acceptance Criteria Met

- ? File: src/rewards/queues/dead-letter.processor.ts
- ? File: src/queue/queue.constants.ts (updated)
- ? DB entity: FailedRewardJob in src/rewards/entities/failed-reward-job.entity.ts
- ? Endpoints: GET /admin/rewards/failed and POST /admin/rewards/failed/:id/replay
- ? Migration: ailed_reward_jobs table
- ? Failed jobs moved to DLQ after 3 failed attempts (exponential backoff)

---

**Bounty claimed - payment address:  xaae0101ac77a2e4e0ea826eb4d309374f029b0a6**