### PR TITLE
feat(auth): add email verification + session management, Adds email verification flow and session management.

### DIFF
--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -25,6 +25,7 @@ import {
 } from '../dto/verify-email.dto';
 import { AuditService } from '../../audit/audit.service';
 import { EmailVerificationService } from '@/modules/auth/services/email-verification.service';
+import { SessionService } from '@/modules/auth/services/session.service';
 
 @Injectable()
 export class AuthService {
@@ -38,6 +39,7 @@ export class AuthService {
     private otpService: OtpService,
     private auditService: AuditService,
     private emailVerificationService: EmailVerificationService,
+    private sessionService: SessionService,
   ) {
     this.redisClient = createClient({
       url: process.env.REDIS_URL || 'redis://localhost:6379',
@@ -132,6 +134,13 @@ export class AuthService {
     await this.redisClient.set(key, refreshToken, {
       EX: 7 * 24 * 60 * 60,
     });
+
+    // Record session metadata in DB (device info can be passed later)
+    try {
+      await this.sessionService.createSession(userId, tokenId);
+    } catch (err) {
+      this.logger.warn('Failed to record session in DB', err as any);
+    }
 
     return { accessToken, refreshToken };
   }

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -24,6 +24,7 @@ import {
   ResendEmailVerificationDto,
 } from '../dto/verify-email.dto';
 import { AuditService } from '../../audit/audit.service';
+import { EmailVerificationService } from '@/modules/auth/services/email-verification.service';
 
 @Injectable()
 export class AuthService {
@@ -36,6 +37,7 @@ export class AuthService {
     private eventEmitter: EventEmitter2,
     private otpService: OtpService,
     private auditService: AuditService,
+    private emailVerificationService: EmailVerificationService,
   ) {
     this.redisClient = createClient({
       url: process.env.REDIS_URL || 'redis://localhost:6379',
@@ -57,6 +59,11 @@ export class AuthService {
       email: user.email,
     });
 
+    // Create email verification token and send email
+    if (user.email) {
+      await this.emailVerificationService.createForUser(user.id);
+    }
+
     const token = this.jwtService.sign({ sub: user.id, email: user.email });
     return { token };
   }
@@ -69,6 +76,10 @@ export class AuthService {
     const passwordMatches = await bcrypt.compare(dto.password, user.password);
     if (!passwordMatches)
       throw new UnauthorizedException('Invalid credentials');
+
+    if (!user.isVerified) {
+      throw new UnauthorizedException('Email not verified');
+    }
 
     return this.generateTokens(user.id, user.email, user.role);
   }
@@ -172,8 +183,8 @@ export class AuthService {
         phoneNumber: verifyOtpDto.phoneNumber,
         firstName: 'Phone',
         lastName: 'User',
-        email: null, // No email for phone users
-        password: null, // No password
+        email: undefined, // No email for phone users
+        password: undefined, // No password
       });
       this.logger.log(
         `New user registered via phone: ${verifyOtpDto.phoneNumber}`,
@@ -200,22 +211,16 @@ export class AuthService {
 
   // Verify email
   async verifyEmail(dto: VerifyEmailDto) {
-    const user = await this.usersService['usersRepository'].findOne({
-      where: {
-        emailVerificationToken: dto.token,
-        emailVerificationExpiry: MoreThan(new Date()),
-      },
-    });
-
-    if (!user) {
+    const record = await this.emailVerificationService.consume(dto.token);
+    if (!record) {
       throw new BadRequestException('Invalid or expired verification token');
     }
 
-    // Clear verification token and mark email as verified
+    const user = record.user;
+    user.isVerified = true;
+    // clear legacy fields if present
     user.emailVerificationToken = null;
     user.emailVerificationExpiry = null;
-    user.isVerified = true;
-
     await this.usersService.save(user);
 
     // Emit email verified event
@@ -225,10 +230,7 @@ export class AuthService {
     });
 
     // Audit log for email verification
-    await this.auditService.logAction(
-      user.id,
-      `Email verified: ${user.email}`,
-    );
+    await this.auditService.logAction(user.id, `Email verified: ${user.email}`);
 
     return { message: 'Email verified successfully' };
   }
@@ -255,15 +257,8 @@ export class AuthService {
       );
     }
 
-    // Generate new verification token (using UUID for consistency with remote)
-    const verificationToken = crypto.randomUUID();
-    const expiryTime = new Date();
-    expiryTime.setHours(expiryTime.getHours() + 24); // 24-hour expiry
-
-    user.emailVerificationToken = verificationToken;
-    user.emailVerificationExpiry = expiryTime;
-
-    await this.usersService.save(user);
+  // Create a new email verification record and send email
+  await this.emailVerificationService.createForUser(user.id);
 
     // Increment rate limit counter
     if (!currentCount) {

--- a/src/database/entities/email-verification.entity.ts
+++ b/src/database/entities/email-verification.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../../entities/user.entity';
+
+@Entity('email_verifications')
+export class EmailVerification {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', unique: true })
+  token: string;
+
+  @Column({ type: 'timestamp' })
+  expiresAt!: Date;
+
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  consumedAt?: Date | null;
+}

--- a/src/database/entities/session.entity.ts
+++ b/src/database/entities/session.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../../entities/user.entity';
+
+@Entity('sessions')
+export class Session {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', unique: true })
+  tokenId: string;
+
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ type: 'varchar', nullable: true })
+  device?: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  ip?: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  userAgent?: string;
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  lastActiveAt: Date;
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
+import { VerifyEmailDto, ResendEmailVerificationDto } from '../../auth/dto/verify-email.dto';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -18,6 +19,18 @@ export class AuthController {
     // - Create user in database
     // - Generate JWT token
     return { message: 'Registration logic to be implemented' };
+  }
+
+  @Post('verify-email')
+  @HttpCode(HttpStatus.OK)
+  async verifyEmail(@Body() dto: VerifyEmailDto) {
+    return this.authService.verifyEmail(dto);
+  }
+
+  @Post('resend-verification')
+  @HttpCode(HttpStatus.OK)
+  async resendVerification(@Body() dto: ResendEmailVerificationDto) {
+    return this.authService.resendEmailVerification(dto);
   }
 
   @Post('login')

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -8,13 +8,15 @@ import { AuthService } from './auth.service';
 import { UsersModule } from '@modules/users/users.module';
 import { EmailVerification } from '../../database/entities/email-verification.entity';
 import { EmailVerificationService } from './services/email-verification.service';
+import { Session } from '../../database/entities/session.entity';
+import { SessionService } from './services/session.service';
 import { NotificationsModule } from '@/notifications/notifications.module';
 
 @Module({
   imports: [
     UsersModule,
     PassportModule,
-    TypeOrmModule.forFeature([EmailVerification]),
+  TypeOrmModule.forFeature([EmailVerification, Session]),
     NotificationsModule,
     JwtModule.registerAsync({
       inject: [ConfigService],
@@ -27,7 +29,7 @@ import { NotificationsModule } from '@/notifications/notifications.module';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, EmailVerificationService],
-  exports: [AuthService, EmailVerificationService],
+  providers: [AuthService, EmailVerificationService, SessionService],
+  exports: [AuthService, EmailVerificationService, SessionService],
 })
 export class AuthModule {}

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -2,14 +2,20 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { UsersModule } from '@modules/users/users.module';
+import { EmailVerification } from '../../database/entities/email-verification.entity';
+import { EmailVerificationService } from './services/email-verification.service';
+import { NotificationsModule } from '@/notifications/notifications.module';
 
 @Module({
   imports: [
     UsersModule,
     PassportModule,
+    TypeOrmModule.forFeature([EmailVerification]),
+    NotificationsModule,
     JwtModule.registerAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
@@ -21,7 +27,7 @@ import { UsersModule } from '@modules/users/users.module';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService],
-  exports: [AuthService],
+  providers: [AuthService, EmailVerificationService],
+  exports: [AuthService, EmailVerificationService],
 })
 export class AuthModule {}

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,15 +1,2 @@
-import { Injectable } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
+export { AuthService } from '../../auth/services/auth.service';
 
-@Injectable()
-export class AuthService {
-  constructor(private readonly jwtService: JwtService) {}
-
-  // TODO: Implement authentication methods
-  // - register(email: string, password: string, phone: string)
-  // - login(email: string, password: string)
-  // - validateUser(email: string, password: string)
-  // - generateToken(userId: string)
-  // - refreshToken(refreshToken: string)
-  // - validateToken(token: string)
-}

--- a/src/modules/auth/services/email-verification.service.ts
+++ b/src/modules/auth/services/email-verification.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import { EmailVerification } from '../../../database/entities/email-verification.entity';
+import { UsersService } from './users.service';
+import { NotificationService } from '../../../notifications/services/notification.service';
+
+@Injectable()
+export class EmailVerificationService {
+  private readonly logger = new Logger(EmailVerificationService.name);
+
+  constructor(
+    @InjectRepository(EmailVerification)
+    private readonly repo: Repository<EmailVerification>,
+    private readonly usersService: UsersService,
+    private readonly notifications: NotificationService,
+  ) {}
+
+  async createForUser(userId: string) {
+    const token = crypto.randomUUID();
+    const expiresAt = new Date(Date.now() + 24 * 3600 * 1000);
+
+    const user = await this.usersService.findById(userId);
+
+    const ev = this.repo.create({ token, expiresAt, user });
+    await this.repo.save(ev);
+
+    // Send email via notifications service (template can be adapted)
+    try {
+      const verificationLink = `${process.env.FRONTEND_URL || 'https://example.com'}/verify-email?token=${token}`;
+      await this.notifications.sendMultiChannel(user.id, {
+        email: { template: 'verify-email', data: { name: user.firstName || user.email, link: verificationLink } },
+      });
+    } catch (err) {
+      this.logger.error('Failed to send verification email', err as any);
+    }
+
+    return { token, expiresAt };
+  }
+
+  async consume(token: string) {
+    const record = await this.repo.findOne({ where: { token }, relations: ['user'] });
+    if (!record) return null;
+    if (record.consumedAt) return null;
+    if (record.expiresAt < new Date()) return null;
+
+    record.consumedAt = new Date();
+    await this.repo.save(record);
+    return record;
+  }
+}

--- a/src/modules/auth/services/session.service.ts
+++ b/src/modules/auth/services/session.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Session } from '../../../database/entities/session.entity';
+import { UsersService } from './users.service';
+
+@Injectable()
+export class SessionService {
+  constructor(
+    @InjectRepository(Session)
+    private readonly repo: Repository<Session>,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async createSession(userId: string, tokenId: string, meta?: { device?: string; ip?: string; userAgent?: string }) {
+    const user = await this.usersService.findById(userId);
+    const session = this.repo.create({
+      tokenId,
+      user,
+      device: meta?.device,
+      ip: meta?.ip,
+      userAgent: meta?.userAgent,
+      isActive: true,
+    });
+    return this.repo.save(session);
+  }
+
+  async listUserSessions(userId: string) {
+    return this.repo.find({ where: { user: { id: userId }, isActive: true }, relations: ['user'] });
+  }
+
+  async revokeSession(tokenId: string) {
+    const session = await this.repo.findOne({ where: { tokenId } });
+    if (!session) return false;
+    session.isActive = false;
+    await this.repo.save(session);
+    return true;
+  }
+
+  async revokeAllSessions(userId: string) {
+    const sessions = await this.repo.find({ where: { user: { id: userId }, isActive: true } });
+    if (sessions.length === 0) return 0;
+    for (const s of sessions) {
+      s.isActive = false;
+    }
+    await this.repo.save(sessions);
+    return sessions.length;
+  }
+
+  async touchSession(tokenId: string) {
+    await this.repo.update({ tokenId }, { lastActiveAt: new Date() });
+  }
+}


### PR DESCRIPTION

- Closes #485

Summary
- Generates email verification tokens with 24-hour expiry and sends verification links via the notifications service.
- Exposes endpoints to verify email and resend verification tokens.
- Adds a sessions table and a SessionService to track active sessions, support multiple concurrent sessions, and revoke single or all sessions.
- Wires new services into the Auth module and requires email verification before login.

Closes
- Closes #484

