### PR TITLE
feat: add TaskFilterService with status, category, date range filtering and presets

### DIFF
--- a/src/modules/health-tasks/services/task-filter.service.ts
+++ b/src/modules/health-tasks/services/task-filter.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, FindOptionsWhere } from 'typeorm';
+import { HealthTask, TaskCategory } from '../../../tasks/entities/health-task.entity';
+
+export interface TaskFilterOptions {
+  status?: string;
+  category?: TaskCategory;
+  priority?: string;
+  createdBy?: string;
+  isActive?: boolean;
+  dateFrom?: Date;
+  dateTo?: Date;
+  presetName?: string;
+}
+
+export interface FilterPreset {
+  name: string;
+  ownerId: string;
+  filters: TaskFilterOptions;
+  createdAt: Date;
+}
+
+@Injectable()
+export class TaskFilterService {
+  private readonly presets = new Map<string, FilterPreset>();
+
+  constructor(
+    @InjectRepository(HealthTask)
+    private readonly taskRepo: Repository<HealthTask>,
+  ) {}
+
+  async filter(options: TaskFilterOptions): Promise<HealthTask[]> {
+    const where: FindOptionsWhere<HealthTask> = {};
+
+    if (options.status) where.status = options.status;
+    if (options.category) where.category = options.category;
+    if (options.isActive !== undefined) where.isActive = options.isActive;
+    if (options.createdBy) where.createdBy = options.createdBy;
+
+    const qb = this.taskRepo.createQueryBuilder('task').where(where);
+
+    if (options.dateFrom && options.dateTo) {
+      qb.andWhere('task.createdAt BETWEEN :from AND :to', {
+        from: options.dateFrom,
+        to: options.dateTo,
+      });
+    } else if (options.dateFrom) {
+      qb.andWhere('task.createdAt >= :from', { from: options.dateFrom });
+    } else if (options.dateTo) {
+      qb.andWhere('task.createdAt <= :to', { to: options.dateTo });
+    }
+
+    return qb.orderBy('task.createdAt', 'DESC').getMany();
+  }
+
+  savePreset(name: string, ownerId: string, filters: TaskFilterOptions): FilterPreset {
+    const key = `${ownerId}:${name}`;
+    const preset: FilterPreset = { name, ownerId, filters, createdAt: new Date() };
+    this.presets.set(key, preset);
+    return preset;
+  }
+
+  getPreset(name: string, ownerId: string): FilterPreset | null {
+    return this.presets.get(`${ownerId}:${name}`) ?? null;
+  }
+
+  listPresets(ownerId: string): FilterPreset[] {
+    return Array.from(this.presets.values()).filter((p) => p.ownerId === ownerId);
+  }
+
+  deletePreset(name: string, ownerId: string): boolean {
+    return this.presets.delete(`${ownerId}:${name}`);
+  }
+
+  async filterWithPreset(presetName: string, ownerId: string): Promise<HealthTask[]> {
+    const preset = this.getPreset(presetName, ownerId);
+    if (!preset) return [];
+    return this.filter(preset.filters);
+  }
+}


### PR DESCRIPTION
## Summary

- Implements `TaskFilterService` supporting independent and combined filters: status, category, active flag, creator, and date range.
- Uses TypeORM QueryBuilder for efficient combined filtering with `AND` conditions.
- Adds filter preset management (save, get, list, delete) keyed per user so users can re-apply common filter combinations.
- Exposes `filterWithPreset()` to run a saved preset in one call.

## Changes

- `src/modules/health-tasks/services/task-filter.service.ts` — new file

closes #509