### PR TITLE
feat:#461 Implement Database Migrations

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,6 +6,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthController } from './auth.controller';
 import { AuthService } from './services/auth.service';
 import { UsersService } from './services/users.service';
+import { PasswordService } from './services/password.service';
+import { JwtTokenService } from './services/jwt.service';
 import { OtpModule } from '../otp/otp.module';
 import { User } from '../entities/user.entity';
 import { JwtStrategy } from './strategies/jwt.strategy';
@@ -24,8 +26,9 @@ import { AuditModule } from '../audit/audit.module';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
+        // Kept for Passport compatibility; JwtTokenService uses RS256 directly.
         secret: configService.get<string>('JWT_SECRET', 'secretKey'),
-        signOptions: { expiresIn: '1h' },
+        signOptions: { expiresIn: '15m' },
       }),
     }),
     AuditModule,
@@ -34,11 +37,13 @@ import { AuditModule } from '../audit/audit.module';
   providers: [
     AuthService,
     UsersService,
+    PasswordService,
+    JwtTokenService,
     JwtStrategy,
     JwtRefreshStrategy,
     JwtAuthGuard,
     JwtRefreshGuard,
   ],
-  exports: [AuthService, UsersService],
+  exports: [AuthService, UsersService, PasswordService, JwtTokenService],
 })
 export class AuthModule {}

--- a/src/auth/services/jwt.service.ts
+++ b/src/auth/services/jwt.service.ts
@@ -1,0 +1,92 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as jwt from 'jsonwebtoken';
+import {
+  TokenPayload,
+  TokenPair,
+  ValidatedToken,
+} from '../../../common/interfaces/token.interface';
+
+@Injectable()
+export class JwtTokenService {
+  private readonly logger = new Logger(JwtTokenService.name);
+
+  private readonly privateKey: string;
+  private readonly publicKey: string;
+
+  private readonly ACCESS_TOKEN_EXPIRY = '15m';
+  private readonly REFRESH_TOKEN_EXPIRY = '7d';
+
+  constructor(private readonly configService: ConfigService) {
+    this.privateKey = this.configService.get<string>('JWT_PRIVATE_KEY', '').replace(/\\n/g, '\n');
+    this.publicKey = this.configService.get<string>('JWT_PUBLIC_KEY', '').replace(/\\n/g, '\n');
+  }
+
+  /**
+   * Generates a short-lived access token (15 minutes).
+   */
+  generateAccessToken(payload: Omit<TokenPayload, 'iat' | 'exp'>): string {
+    return jwt.sign(payload, this.privateKey, {
+      algorithm: 'RS256',
+      expiresIn: this.ACCESS_TOKEN_EXPIRY,
+    });
+  }
+
+  /**
+   * Generates a long-lived refresh token (7 days).
+   */
+  generateRefreshToken(payload: Omit<TokenPayload, 'iat' | 'exp'>): string {
+    return jwt.sign(payload, this.privateKey, {
+      algorithm: 'RS256',
+      expiresIn: this.REFRESH_TOKEN_EXPIRY,
+    });
+  }
+
+  /**
+   * Generates both access and refresh tokens in a single call.
+   */
+  generateTokenPair(payload: Omit<TokenPayload, 'iat' | 'exp'>): TokenPair {
+    return {
+      accessToken: this.generateAccessToken(payload),
+      refreshToken: this.generateRefreshToken(payload),
+    };
+  }
+
+  /**
+   * Validates a JWT token and returns the decoded payload or null.
+   * Never throws — all errors are captured in the ValidatedToken shape.
+   */
+  validateToken(token: string): ValidatedToken {
+    try {
+      const payload = jwt.verify(token, this.publicKey, {
+        algorithms: ['RS256'],
+      }) as TokenPayload;
+
+      return { payload, expired: false };
+    } catch (error) {
+      if (error instanceof jwt.TokenExpiredError) {
+        this.logger.warn('Token has expired');
+        return { payload: null, expired: true, error: 'Token expired' };
+      }
+
+      this.logger.warn('Token validation failed', error?.message);
+      return { payload: null, expired: false, error: error?.message ?? 'Invalid token' };
+    }
+  }
+
+  /**
+   * Rotates a refresh token — validates the old one and, if valid,
+   * issues a new access + refresh pair.
+   */
+  refreshTokenPair(refreshToken: string): TokenPair | null {
+    const { payload, expired, error } = this.validateToken(refreshToken);
+
+    if (!payload || expired) {
+      this.logger.warn('Refresh token rejected', error);
+      return null;
+    }
+
+    const { iat, exp, ...rest } = payload;
+    return this.generateTokenPair(rest);
+  }
+}

--- a/src/common/interfaces/token.interface.ts
+++ b/src/common/interfaces/token.interface.ts
@@ -1,0 +1,19 @@
+export interface TokenPayload {
+  sub: string; // User ID
+  email: string;
+  roles: string[];
+  permissions?: string[];
+  iat?: number;
+  exp?: number;
+}
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface ValidatedToken {
+  payload: TokenPayload | null;
+  expired: boolean;
+  error?: string;
+}

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -16,7 +16,11 @@ import { TransactionService } from './services/transaction.service';
         database: configService.get<string>('DB_NAME', 'stellar_uzima'),
         entities: [__dirname + '/../**/entities/*.entity{.ts,.js}'],
         migrations: [__dirname + '/../database/migrations/*{.ts,.js}'],
-        synchronize: configService.get<boolean>('DB_SYNCHRONIZE', true),
+        // Never auto-sync in production — rely solely on migrations
+        synchronize:
+          configService.get<string>('NODE_ENV') !== 'production' &&
+          configService.get<boolean>('DB_SYNCHRONIZE', false),
+        migrationsRun: configService.get<string>('NODE_ENV') === 'production',
         logging: configService.get<boolean>('DB_LOGGING', false),
       }),
     }),

--- a/src/database/migrations/1700000000000-InitialSchema.ts
+++ b/src/database/migrations/1700000000000-InitialSchema.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class InitialSchema1700000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Enable uuid extension if not present
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'users',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'email', type: 'varchar', length: '255', isUnique: true, isNullable: false },
+          { name: 'password_hash', type: 'varchar', length: '255', isNullable: false },
+          { name: 'first_name', type: 'varchar', length: '100', isNullable: true },
+          { name: 'last_name', type: 'varchar', length: '100', isNullable: true },
+          {
+            name: 'roles',
+            type: 'text',
+            isArray: true,
+            default: '\'{"user"}\'',
+            isNullable: false,
+          },
+          { name: 'is_active', type: 'boolean', default: true },
+          { name: 'refresh_token_hash', type: 'varchar', length: '255', isNullable: true },
+          { name: 'created_at', type: 'timestamptz', default: 'now()' },
+          { name: 'updated_at', type: 'timestamptz', default: 'now()' },
+        ],
+      }),
+      true // ifNotExists
+    );
+
+    await queryRunner.createIndex(
+      'users',
+      new TableIndex({ name: 'IDX_USERS_EMAIL', columnNames: ['email'] })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('users', 'IDX_USERS_EMAIL');
+    await queryRunner.dropTable('users', true);
+  }
+}


### PR DESCRIPTION
PR Description
feat: password hashing, JWT token service, and TypeORM migrations
Introduces three foundational pieces of the auth and persistence layers:
Password Service — PasswordService hashes passwords with bcrypt (10 rounds) and provides a safe comparePasswords method. Raw passwords are never logged, and all bcrypt errors surface as typed NestJS exceptions.
JWT Token Service — JwtTokenService issues RS256-signed access tokens (15 min) and refresh tokens (7 days). A shared TokenPayload / TokenPair / ValidatedToken interface in src/common/interfaces/token.interface.ts gives the whole codebase a single source of truth for token shapes. Token refresh logic is encapsulated in refreshTokenPair().
TypeORM Migrations — adds the initial users table migration with full up / down support. DatabaseModule is updated to disable synchronize in production and run migrations automatically on startup.
Both new services are registered and exported from AuthModule so downstream modules (e.g. a future ProfileModule) can inject them without circular dependencies.

Closes #458
Closes #457
Closes #460
Closes #461