### PR TITLE
feat: add GitHub issue and PR templates (#651)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report a reproducible bug to help us improve Uzima Backend
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+<!-- What actually happened. Include error messages, stack traces, or screenshots if applicable. -->
+
+## Environment
+- **Node.js version:**
+- **NestJS version:**
+- **OS:**
+- **Branch/Commit:**
+
+## Additional Context
+<!-- Any other context about the problem (logs, related issues, etc.). -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for Uzima Backend
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Motivation
+<!-- Why is this feature needed? What problem does it solve? Who benefits from it? -->
+
+## Proposed Solution
+<!-- Describe the feature you'd like. Be as specific as possible. -->
+
+## Alternatives Considered
+<!-- Have you considered any alternative approaches or workarounds? -->
+
+## Acceptance Criteria
+<!-- List the conditions that must be met for this feature to be considered complete. -->
+- [ ] 
+- [ ] 
+
+## Additional Context
+<!-- Any other context, mockups, references, or related issues. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Description
+<!-- Summarize the changes and the motivation behind them. Link the related issue below. -->
+
+Closes #<!-- issue number -->
+
+## Type of Change
+<!-- Check all that apply. -->
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactor / code cleanup
+- [ ] Documentation update
+- [ ] CI/CD or configuration change
+
+## How Has This Been Tested?
+<!-- Describe the tests you ran and how to reproduce them. -->
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] Manual testing
+
+## Checklist
+- [ ] My code follows the project's style guidelines (`npm run lint` passes)
+- [ ] I have performed a self-review of my code
+- [ ] I have added or updated tests that cover my changes
+- [ ] All existing tests pass (`npm run test`)
+- [ ] I have updated relevant documentation (README, JSDoc, etc.)
+- [ ] No secrets or sensitive data are included in this PR
+- [ ] The branch is up to date with `main`
+
+## Screenshots / Logs (if applicable)
+<!-- Attach any relevant screenshots, API responses, or log output. -->


### PR DESCRIPTION
Summary
Closes #651

Adds GitHub issue and PR templates to standardize contributions and reduce back-and-forth during review.

Changes
bug_report.md
 — guides reporters through description, steps to reproduce, expected vs actual behavior, and environment details
feature_request.md
 — prompts contributors for motivation, proposed solution, alternatives considered, and acceptance criteria
PULL_REQUEST_TEMPLATE.md
 — pre-populates PRs with a type-of-change selector, testing notes, and a checklist covering lint, tests, docs, secrets, and branch status
Type of Change
 Documentation update / CI configuration
Checklist
✅ No code logic changed
✅ No tests required
✅ Templates follow GitHub's expected file paths and front-matter format