### PR TITLE
feat: implement JWT refresh token rotation

### DIFF
--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -234,6 +234,11 @@ export class AuthService {
       if (!storedToken || storedToken !== refreshToken) {
         // Replay attack or invalid token: clear all user sessions
         await this.clearAllUserRefreshTokens(userId);
+        // Also clear persisted token on the user entity
+        const user = await this.usersService.findById(userId);
+        user.refreshToken = null;
+        user.refreshTokenExpiry = null;
+        await this.usersService.save(user);
         this.eventEmitter.emit('auth.suspicious_activity', {
           userId,
           reason: 'Invalid or reused refresh token',
@@ -241,10 +246,24 @@ export class AuthService {
         throw new UnauthorizedException('Invalid refresh token');
       }
 
-      // Delete the used token
-      await this.redisClient.del(key);
-
+      // Validate against persisted hashed token on user entity
       const user = await this.usersService.findById(userId);
+      if (
+        !user.refreshToken ||
+        !user.refreshTokenExpiry ||
+        user.refreshTokenExpiry < new Date() ||
+        !(await bcrypt.compare(refreshToken, user.refreshToken))
+      ) {
+        await this.redisClient.del(key);
+        throw new UnauthorizedException('Invalid refresh token');
+      }
+
+      // Delete the used token (rotation: old token invalidated)
+      await this.redisClient.del(key);
+      user.refreshToken = null;
+      user.refreshTokenExpiry = null;
+      await this.usersService.save(user);
+
       return this.generateTokens(user.id, user.email, user.role);
     } catch (error: any) {
       if (error instanceof UnauthorizedException) {
@@ -256,6 +275,7 @@ export class AuthService {
 
   private async generateTokens(userId: string, email: string, role: Role) {
     const tokenId = crypto.randomUUID();
+    const refreshExpiry = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
 
     const accessToken = this.jwtService.sign({ sub: userId, email, role }, { expiresIn: '15m' });
     const refreshToken = this.jwtService.sign(
@@ -263,10 +283,16 @@ export class AuthService {
       { expiresIn: '7d' }
     );
 
+    // Store in Redis for fast lookup
     const key = `refresh:${userId}:${tokenId}`;
-    await this.redisClient.set(key, refreshToken, {
-      EX: 7 * 24 * 60 * 60,
-    });
+    await this.redisClient.set(key, refreshToken, { EX: 7 * 24 * 60 * 60 });
+
+    // Persist hashed refresh token to user entity for durable rotation
+    const hashedRefreshToken = await bcrypt.hash(refreshToken, 10);
+    const user = await this.usersService.findById(userId);
+    user.refreshToken = hashedRefreshToken;
+    user.refreshTokenExpiry = refreshExpiry;
+    await this.usersService.save(user);
 
     // Record session metadata in DB (device info can be passed later)
     try {
@@ -351,6 +377,16 @@ export class AuthService {
       } catch (redisError: any) {
         // Redis failure shouldn't fail the logout
         this.logger.warn(`Redis cleanup failed for user ${userId}: ${redisError.message}`);
+      }
+
+      // Clear persisted refresh token on user entity
+      try {
+        const user = await this.usersService.findById(userId);
+        user.refreshToken = null;
+        user.refreshTokenExpiry = null;
+        await this.usersService.save(user);
+      } catch (err: any) {
+        this.logger.warn(`Failed to clear user refresh token fields: ${err.message}`);
       }
 
       // Log successful logout with performance metrics

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -104,6 +104,12 @@ export class User {
   @Column({ type: 'timestamp', nullable: true })
   lockedUntil: Date | null;
 
+  @Column({ type: 'varchar', nullable: true, select: false })
+  refreshToken: string | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  refreshTokenExpiry: Date | null;
+
   @ManyToOne(() => User, { nullable: true })
   referredBy?: User;
 

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 import { JwtService } from '@nestjs/jwt';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
@@ -149,10 +150,13 @@ describe('AuthService', () => {
         ...baseUser,
         failedLoginAttempts: 2,
         lockedUntil: null,
+        refreshToken: null,
+        refreshTokenExpiry: null,
       };
       mockUsersService.findByEmail.mockResolvedValue(user);
       mockUsersService.canUserLogin.mockResolvedValue({ canLogin: true });
       mockUsersService.getProfile.mockResolvedValue({ id: user.id, email: user.email });
+      mockUsersService.findById.mockResolvedValue(user);
       mockUsersService.save.mockImplementation(async (u) => u);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
       mockJwtService.sign.mockReturnValue('token');
@@ -164,6 +168,94 @@ describe('AuthService', () => {
       expect(mockUsersService.save).toHaveBeenCalledWith(
         expect.objectContaining({ failedLoginAttempts: 0, lockedUntil: null }),
       );
+    });
+  });
+
+  describe('refresh token rotation', () => {
+    const userId = 'user-1';
+    const tokenId = 'token-id-abc';
+    const refreshToken = 'valid-refresh-token';
+
+    it('returns new access and refresh tokens on valid refresh', async () => {
+      mockJwtService.verify.mockReturnValue({ sub: userId, tokenId });
+      mockTokenBlacklistRepository.findOne.mockResolvedValue(null);
+      mockRedisClient.get.mockResolvedValue(refreshToken);
+      const user = {
+        ...baseUser,
+        refreshToken: 'hashed',
+        refreshTokenExpiry: new Date(Date.now() + 86400000),
+      };
+      mockUsersService.findById.mockResolvedValue(user);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      mockRedisClient.del.mockResolvedValue(1);
+      mockUsersService.save.mockImplementation(async (u) => u);
+      mockJwtService.sign
+        .mockReturnValueOnce('new-access-token')
+        .mockReturnValueOnce('new-refresh-token');
+      mockRedisClient.set.mockResolvedValue('OK');
+      mockSessionService.createSession.mockResolvedValue({});
+
+      const result = await authService.refresh(refreshToken);
+
+      expect(result).toEqual({ accessToken: 'new-access-token', refreshToken: 'new-refresh-token' });
+    });
+
+    it('invalidates old refresh token after use (rotation)', async () => {
+      mockJwtService.verify.mockReturnValue({ sub: userId, tokenId });
+      mockTokenBlacklistRepository.findOne.mockResolvedValue(null);
+      mockRedisClient.get.mockResolvedValue(refreshToken);
+      const user = {
+        ...baseUser,
+        refreshToken: 'hashed',
+        refreshTokenExpiry: new Date(Date.now() + 86400000),
+      };
+      mockUsersService.findById.mockResolvedValue(user);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      mockRedisClient.del.mockResolvedValue(1);
+      mockUsersService.save.mockImplementation(async (u) => u);
+      mockJwtService.sign.mockReturnValue('new-token');
+      mockRedisClient.set.mockResolvedValue('OK');
+      mockSessionService.createSession.mockResolvedValue({});
+
+      await authService.refresh(refreshToken);
+
+      expect(mockRedisClient.del).toHaveBeenCalledWith(`refresh:${userId}:${tokenId}`);
+      expect(mockUsersService.save).toHaveBeenCalledWith(
+        expect.objectContaining({ refreshToken: null, refreshTokenExpiry: null }),
+      );
+    });
+
+    it('returns 401 when reusing an old (already rotated) refresh token', async () => {
+      mockJwtService.verify.mockReturnValue({ sub: userId, tokenId });
+      mockTokenBlacklistRepository.findOne.mockResolvedValue(null);
+      mockRedisClient.get.mockResolvedValue(null); // not in Redis → already rotated
+      mockRedisClient.keys.mockResolvedValue([]);
+      mockUsersService.findById.mockResolvedValue({ ...baseUser, refreshToken: null, refreshTokenExpiry: null });
+      mockUsersService.save.mockImplementation(async (u) => u);
+
+      await expect(authService.refresh(refreshToken)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('emits suspicious_activity event on replay attack', async () => {
+      mockJwtService.verify.mockReturnValue({ sub: userId, tokenId });
+      mockTokenBlacklistRepository.findOne.mockResolvedValue(null);
+      mockRedisClient.get.mockResolvedValue(null);
+      mockRedisClient.keys.mockResolvedValue([]);
+      mockUsersService.findById.mockResolvedValue({ ...baseUser, refreshToken: null, refreshTokenExpiry: null });
+      mockUsersService.save.mockImplementation(async (u) => u);
+
+      await expect(authService.refresh(refreshToken)).rejects.toThrow(UnauthorizedException);
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+        'auth.suspicious_activity',
+        expect.objectContaining({ userId, reason: expect.stringContaining('reused') }),
+      );
+    });
+
+    it('returns 401 when refresh token is blacklisted', async () => {
+      mockJwtService.verify.mockReturnValue({ sub: userId, tokenId });
+      mockTokenBlacklistRepository.findOne.mockResolvedValue({ token: refreshToken });
+
+      await expect(authService.refresh(refreshToken)).rejects.toThrow(UnauthorizedException);
     });
   });
 


### PR DESCRIPTION
## Summary

Implements secure JWT refresh token rotation.

## Changes

- **User entity**: Added `refreshToken` (hashed) and `refreshTokenExpiry` fields
- **AuthService**:
  - Persists hashed refresh token on login/register
  - Validates against stored hash on each refresh
  - Rotates token on every use (old token immediately invalidated)
  - Clears token fields on logout
  - Detects replay attacks and emits `suspicious_activity` event
- **Tests**: Unit tests covering valid refresh, rotation, replay attack (401), and blacklisted token (401)

## Testing

```bash
npm run test -- --testPathPattern=auth.service.spec.ts
```

Closes #654