### PR TITLE
feat: add email templating service for transactional emails (issue #664)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "twilio": "^6.0.0",
     "otplib": "^12.0.0",
     "qrcode": "^1.5.1",
-    "typeorm": "^0.3.0"
+    "typeorm": "^0.3.0",
+    "nodemailer": "^6.9.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.2.0",
@@ -88,6 +89,7 @@
     "ts-loader": "^9.4.0",
     "ts-node": "^10.9.0",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.1.0"
+    "typescript": "^5.1.0",
+    "@types/nodemailer": "^6.4.0"
   }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -24,6 +24,7 @@ import { OtpModule } from '../../otp/otp.module';
 import { AuditModule } from '../../audit/audit.module';
 import { UsersService } from '../../auth/services/users.service';
 import { DatabaseModule } from '../../database/database.module';
+import { EmailTemplateService } from '../../shared/notifications/services/email-template.service';
 
 @Module({
   imports: [
@@ -55,6 +56,7 @@ import { DatabaseModule } from '../../database/database.module';
     JwtAuthGuard,
     JwtRefreshGuard,
     RolesGuard,
+    EmailTemplateService,
   ],
   exports: [
     AuthService,
@@ -64,6 +66,7 @@ import { DatabaseModule } from '../../database/database.module';
     RolesGuard,
     JwtAuthGuard,
     JwtRefreshGuard,
+    EmailTemplateService,
   ],
 })
 export class AuthModule {}

--- a/src/modules/auth/services/email-verification.service.ts
+++ b/src/modules/auth/services/email-verification.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import * as crypto from 'crypto';
 import { EmailVerification } from '../../../database/entities/email-verification.entity';
 import { UsersService } from '../../../auth/services/users.service';
-import { NotificationService } from '../../../notifications/services/notification.service';
+import { EmailTemplateService } from '../../../shared/notifications/services/email-template.service';
 
 @Injectable()
 export class EmailVerificationService {
@@ -14,7 +14,7 @@ export class EmailVerificationService {
     @InjectRepository(EmailVerification)
     private readonly repo: Repository<EmailVerification>,
     private readonly usersService: UsersService,
-    private readonly notifications: NotificationService,
+    private readonly emailTemplateService: EmailTemplateService,
   ) {}
 
   async createForUser(userId: string) {
@@ -26,11 +26,16 @@ export class EmailVerificationService {
     const ev = this.repo.create({ token, expiresAt, user });
     await this.repo.save(ev);
 
-    // Send email via notifications service (template can be adapted)
+    // Send HTML verification email via EmailTemplateService (issue #664)
     try {
-      const verificationLink = `${process.env.FRONTEND_URL || 'https://example.com'}/verify-email?token=${token}`;
-      await this.notifications.sendMultiChannel(user.id, {
-        email: { template: 'verify-email', data: { name: user.firstName || user.email, link: verificationLink } },
+      const frontendUrl = process.env.FRONTEND_URL || 'https://app.stellaruzima.com';
+      const verificationLink = `${frontendUrl}/verify-email?token=${token}`;
+
+      await this.emailTemplateService.sendEmailVerification(user.email, {
+        name: user.firstName || user.email,
+        verificationLink,
+        privacyUrl: `${frontendUrl}/privacy`,
+        unsubscribeUrl: `${frontendUrl}/unsubscribe`,
       });
     } catch (err) {
       this.logger.error('Failed to send verification email', err as any);

--- a/src/shared/notifications/services/email-template.service.spec.ts
+++ b/src/shared/notifications/services/email-template.service.spec.ts
@@ -1,0 +1,368 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { EmailTemplateService, TemplateName } from './email-template.service';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
+
+/** Minimal ConfigService stub — returns no mail env vars so transporter stays null. */
+const mockConfigService = {
+  get: jest.fn((key: string, fallback?: string) => fallback ?? undefined),
+};
+
+async function buildService(): Promise<EmailTemplateService> {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      EmailTemplateService,
+      { provide: ConfigService, useValue: mockConfigService },
+    ],
+  }).compile();
+  return module.get<EmailTemplateService>(EmailTemplateService);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EmailTemplateService', () => {
+  let service: EmailTemplateService;
+
+  beforeEach(async () => {
+    service = await buildService();
+    jest.clearAllMocks();
+  });
+
+  // ── Service setup ───────────────────────────────────────────────────────────
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ── Template files exist ────────────────────────────────────────────────────
+
+  describe('template files', () => {
+    const templates: TemplateName[] = [
+      'welcome',
+      'password-reset',
+      'email-verification',
+      'task-reminder',
+    ];
+
+    it.each(templates)('template file "%s.html" should exist on disk', (name) => {
+      const filePath = path.join(TEMPLATES_DIR, `${name}.html`);
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+
+    it.each(templates)('template file "%s.html" should be valid HTML', (name) => {
+      const filePath = path.join(TEMPLATES_DIR, `${name}.html`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('<!DOCTYPE html>');
+      expect(content).toContain('<html');
+      expect(content).toContain('</html>');
+    });
+
+    it.each(templates)('template file "%s.html" should have a viewport meta tag (mobile-responsive)', (name) => {
+      const filePath = path.join(TEMPLATES_DIR, `${name}.html`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('viewport');
+      expect(content).toContain('width=device-width');
+    });
+
+    it.each(templates)('template file "%s.html" should have a @media query for mobile', (name) => {
+      const filePath = path.join(TEMPLATES_DIR, `${name}.html`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('@media');
+      expect(content).toContain('max-width');
+    });
+  });
+
+  // ── renderTemplate — welcome ────────────────────────────────────────────────
+
+  describe('renderTemplate("welcome")', () => {
+    const data = {
+      name: 'Alice',
+      dashboardUrl: 'https://app.stellaruzima.com/dashboard',
+      privacyUrl: 'https://stellaruzima.com/privacy',
+      unsubscribeUrl: 'https://stellaruzima.com/unsubscribe',
+    };
+
+    it('should return an HTML string', () => {
+      const html = service.renderTemplate('welcome', data);
+      expect(typeof html).toBe('string');
+      expect(html.length).toBeGreaterThan(0);
+    });
+
+    it('should contain the user name', () => {
+      const html = service.renderTemplate('welcome', data);
+      expect(html).toContain('Alice');
+    });
+
+    it('should contain the dashboard URL', () => {
+      const html = service.renderTemplate('welcome', data);
+      expect(html).toContain('https://app.stellaruzima.com/dashboard');
+    });
+
+    it('should not contain un-replaced {{placeholders}}', () => {
+      const html = service.renderTemplate('welcome', data);
+      expect(html).not.toMatch(/\{\{[^}]+\}\}/);
+    });
+
+    it('should escape HTML special characters in user data', () => {
+      const html = service.renderTemplate('welcome', {
+        ...data,
+        name: '<script>alert("xss")</script>',
+      });
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+  });
+
+  // ── renderTemplate — password-reset ────────────────────────────────────────
+
+  describe('renderTemplate("password-reset")', () => {
+    const data = {
+      name: 'Bob',
+      resetLink: 'https://app.stellaruzima.com/reset?token=abc123',
+      privacyUrl: 'https://stellaruzima.com/privacy',
+      unsubscribeUrl: 'https://stellaruzima.com/unsubscribe',
+    };
+
+    it('should contain the user name', () => {
+      const html = service.renderTemplate('password-reset', data);
+      expect(html).toContain('Bob');
+    });
+
+    it('should contain the reset link', () => {
+      const html = service.renderTemplate('password-reset', data);
+      expect(html).toContain('https://app.stellaruzima.com/reset?token=abc123');
+    });
+
+    it('should not contain un-replaced {{placeholders}}', () => {
+      const html = service.renderTemplate('password-reset', data);
+      expect(html).not.toMatch(/\{\{[^}]+\}\}/);
+    });
+
+    it('should mention the 1-hour expiry', () => {
+      const html = service.renderTemplate('password-reset', data);
+      expect(html).toContain('1 hour');
+    });
+  });
+
+  // ── renderTemplate — email-verification ────────────────────────────────────
+
+  describe('renderTemplate("email-verification")', () => {
+    const data = {
+      name: 'Carol',
+      verificationLink: 'https://app.stellaruzima.com/verify-email?token=xyz789',
+      privacyUrl: 'https://stellaruzima.com/privacy',
+      unsubscribeUrl: 'https://stellaruzima.com/unsubscribe',
+    };
+
+    it('should contain the user name', () => {
+      const html = service.renderTemplate('email-verification', data);
+      expect(html).toContain('Carol');
+    });
+
+    it('should contain the verification link', () => {
+      const html = service.renderTemplate('email-verification', data);
+      expect(html).toContain('https://app.stellaruzima.com/verify-email?token=xyz789');
+    });
+
+    it('should not contain un-replaced {{placeholders}}', () => {
+      const html = service.renderTemplate('email-verification', data);
+      expect(html).not.toMatch(/\{\{[^}]+\}\}/);
+    });
+
+    it('should mention the 24-hour expiry', () => {
+      const html = service.renderTemplate('email-verification', data);
+      expect(html).toContain('24 hour');
+    });
+  });
+
+  // ── renderTemplate — task-reminder ─────────────────────────────────────────
+
+  describe('renderTemplate("task-reminder")', () => {
+    const data = {
+      name: 'Dave',
+      pendingCount: 3,
+      dashboardUrl: 'https://app.stellaruzima.com/tasks',
+      streakDays: 7,
+      tasks: [
+        { icon: '🏃', name: 'Morning run', reward: '0.5' },
+        { icon: '💧', name: 'Drink 2L of water', reward: '0.3' },
+      ],
+      preferencesUrl: 'https://app.stellaruzima.com/preferences',
+      privacyUrl: 'https://stellaruzima.com/privacy',
+      unsubscribeUrl: 'https://stellaruzima.com/unsubscribe',
+    };
+
+    it('should contain the user name', () => {
+      const html = service.renderTemplate('task-reminder', data);
+      expect(html).toContain('Dave');
+    });
+
+    it('should contain the pending task count', () => {
+      const html = service.renderTemplate('task-reminder', data);
+      expect(html).toContain('3');
+    });
+
+    it('should contain the streak days when provided', () => {
+      const html = service.renderTemplate('task-reminder', data);
+      expect(html).toContain('7');
+    });
+
+    it('should contain task names when tasks array is provided', () => {
+      const html = service.renderTemplate('task-reminder', data);
+      expect(html).toContain('Morning run');
+      expect(html).toContain('Drink 2L of water');
+    });
+
+    it('should not contain un-replaced {{placeholders}}', () => {
+      const html = service.renderTemplate('task-reminder', data);
+      expect(html).not.toMatch(/\{\{[^}]+\}\}/);
+    });
+
+    it('should render without tasks array (optional)', () => {
+      const dataNoTasks = { ...data, tasks: undefined };
+      expect(() => service.renderTemplate('task-reminder', dataNoTasks)).not.toThrow();
+    });
+
+    it('should render without streakDays (optional)', () => {
+      const dataNoStreak = { ...data, streakDays: undefined };
+      const html = service.renderTemplate('task-reminder', dataNoStreak);
+      expect(html).not.toContain('Day streak');
+    });
+  });
+
+  // ── Unknown template ────────────────────────────────────────────────────────
+
+  describe('renderTemplate — unknown template', () => {
+    it('should throw an error for a non-existent template', () => {
+      expect(() =>
+        service.renderTemplate('nonexistent' as TemplateName, {} as any),
+      ).toThrow(/template not found/i);
+    });
+  });
+
+  // ── Template caching ────────────────────────────────────────────────────────
+
+  describe('template caching', () => {
+    it('should return the same result on repeated calls (cache hit)', () => {
+      const data = {
+        name: 'Eve',
+        dashboardUrl: 'https://example.com',
+      };
+      const first = service.renderTemplate('welcome', data);
+      const second = service.renderTemplate('welcome', data);
+      expect(first).toBe(second);
+    });
+  });
+
+  // ── sendEmail — no transporter ──────────────────────────────────────────────
+
+  describe('sendEmail', () => {
+    it('should return false when the transporter is not configured', async () => {
+      const result = await service.sendEmail({
+        to: 'test@example.com',
+        subject: 'Test',
+        template: 'welcome',
+        data: { name: 'Test', dashboardUrl: 'https://example.com' },
+      });
+      expect(result).toBe(false);
+    });
+  });
+
+  // ── Convenience methods ─────────────────────────────────────────────────────
+
+  describe('convenience helpers', () => {
+    it('sendWelcomeEmail should call sendEmail with correct template', async () => {
+      const spy = jest.spyOn(service, 'sendEmail').mockResolvedValue(false);
+      await service.sendWelcomeEmail('a@b.com', {
+        name: 'Frank',
+        dashboardUrl: 'https://example.com',
+      });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ template: 'welcome', to: 'a@b.com' }),
+      );
+    });
+
+    it('sendPasswordResetEmail should call sendEmail with correct template', async () => {
+      const spy = jest.spyOn(service, 'sendEmail').mockResolvedValue(false);
+      await service.sendPasswordResetEmail('a@b.com', {
+        name: 'Grace',
+        resetLink: 'https://example.com/reset',
+      });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ template: 'password-reset', to: 'a@b.com' }),
+      );
+    });
+
+    it('sendEmailVerification should call sendEmail with correct template', async () => {
+      const spy = jest.spyOn(service, 'sendEmail').mockResolvedValue(false);
+      await service.sendEmailVerification('a@b.com', {
+        name: 'Hank',
+        verificationLink: 'https://example.com/verify',
+      });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ template: 'email-verification', to: 'a@b.com' }),
+      );
+    });
+
+    it('sendTaskReminder should call sendEmail with correct template', async () => {
+      const spy = jest.spyOn(service, 'sendEmail').mockResolvedValue(false);
+      await service.sendTaskReminder('a@b.com', {
+        name: 'Ivy',
+        pendingCount: 2,
+        dashboardUrl: 'https://example.com/tasks',
+      });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ template: 'task-reminder', to: 'a@b.com' }),
+      );
+    });
+
+    it('sendTaskReminder subject should be singular when pendingCount is 1', async () => {
+      const spy = jest.spyOn(service, 'sendEmail').mockResolvedValue(false);
+      await service.sendTaskReminder('a@b.com', {
+        name: 'Jack',
+        pendingCount: 1,
+        dashboardUrl: 'https://example.com/tasks',
+      });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ subject: expect.stringContaining('1 task left') }),
+      );
+    });
+
+    it('sendTaskReminder subject should be plural when pendingCount > 1', async () => {
+      const spy = jest.spyOn(service, 'sendEmail').mockResolvedValue(false);
+      await service.sendTaskReminder('a@b.com', {
+        name: 'Kate',
+        pendingCount: 5,
+        dashboardUrl: 'https://example.com/tasks',
+      });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ subject: expect.stringContaining('5 tasks left') }),
+      );
+    });
+  });
+
+  // ── XSS / injection guard ───────────────────────────────────────────────────
+
+  describe('XSS protection', () => {
+    it('should escape & < > " \' in all template variables', () => {
+      const dangerous = `<script>alert('xss')</script> & "quoted"`;
+      const html = service.renderTemplate('welcome', {
+        name: dangerous,
+        dashboardUrl: 'https://example.com',
+      });
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('&lt;script&gt;');
+      expect(html).toContain('&amp;');
+      expect(html).toContain('&quot;');
+    });
+  });
+});

--- a/src/shared/notifications/services/email-template.service.ts
+++ b/src/shared/notifications/services/email-template.service.ts
@@ -1,0 +1,275 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as nodemailer from 'nodemailer';
+import { ConfigService } from '@nestjs/config';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Template data interfaces
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface WelcomeTemplateData {
+  name: string;
+  dashboardUrl: string;
+  privacyUrl?: string;
+  unsubscribeUrl?: string;
+}
+
+export interface PasswordResetTemplateData {
+  name: string;
+  resetLink: string;
+  privacyUrl?: string;
+  unsubscribeUrl?: string;
+}
+
+export interface EmailVerificationTemplateData {
+  name: string;
+  verificationLink: string;
+  privacyUrl?: string;
+  unsubscribeUrl?: string;
+}
+
+export interface TaskReminderTask {
+  icon: string;
+  name: string;
+  reward: string;
+}
+
+export interface TaskReminderTemplateData {
+  name: string;
+  pendingCount: number;
+  dashboardUrl: string;
+  tasks?: TaskReminderTask[];
+  streakDays?: number;
+  preferencesUrl?: string;
+  privacyUrl?: string;
+  unsubscribeUrl?: string;
+}
+
+export type TemplateData =
+  | WelcomeTemplateData
+  | PasswordResetTemplateData
+  | EmailVerificationTemplateData
+  | TaskReminderTemplateData;
+
+export type TemplateName =
+  | 'welcome'
+  | 'password-reset'
+  | 'email-verification'
+  | 'task-reminder';
+
+export interface SendEmailOptions {
+  to: string;
+  subject: string;
+  template: TemplateName;
+  data: TemplateData;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EmailTemplateService
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Issue #664 — Email templating service for transactional emails.
+ *
+ * Loads HTML templates from disk, performs variable interpolation, and
+ * dispatches emails via nodemailer.  All template files live in
+ * `src/shared/notifications/templates/`.
+ *
+ * Variable syntax: `{{variableName}}` for simple substitutions.
+ * Conditional blocks: `{{#variable}}...{{/variable}}` (renders when truthy).
+ * Array iteration: `{{#array}}...{{name}}...{{/array}}`.
+ */
+@Injectable()
+export class EmailTemplateService {
+  private readonly logger = new Logger(EmailTemplateService.name);
+  private readonly templateDir: string;
+  private readonly templateCache = new Map<string, string>();
+  private transporter: nodemailer.Transporter | null = null;
+
+  constructor(private readonly configService: ConfigService) {
+    this.templateDir = path.join(__dirname, '..', 'templates');
+    this.initTransporter();
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  /**
+   * Render an HTML template with the supplied data and return the HTML string.
+   * Throws if the template file cannot be found.
+   */
+  renderTemplate(template: TemplateName, data: TemplateData): string {
+    const raw = this.loadTemplate(template);
+    return this.interpolate(raw, data as Record<string, unknown>);
+  }
+
+  /**
+   * Send a transactional email using an HTML template.
+   * Returns `true` on success, `false` if the transporter is not configured.
+   */
+  async sendEmail(options: SendEmailOptions): Promise<boolean> {
+    if (!this.transporter) {
+      this.logger.warn(
+        'Email transporter is not configured. Set MAIL_HOST, MAIL_USER, and MAIL_PASSWORD env vars.',
+      );
+      return false;
+    }
+
+    const html = this.renderTemplate(options.template, options.data);
+    const fromName = this.configService.get<string>('MAIL_FROM_NAME', 'Stellar Uzima');
+    const fromAddr = this.configService.get<string>('MAIL_USER', 'no-reply@stellaruzima.com');
+
+    try {
+      await this.transporter.sendMail({
+        from: `"${fromName}" <${fromAddr}>`,
+        to: options.to,
+        subject: options.subject,
+        html,
+      });
+      this.logger.log(`Email sent: template="${options.template}" to="${options.to}"`);
+      return true;
+    } catch (error) {
+      this.logger.error(
+        `Failed to send email: template="${options.template}" to="${options.to}"`,
+        error,
+      );
+      return false;
+    }
+  }
+
+  // ── Convenience methods ─────────────────────────────────────────────────────
+
+  async sendWelcomeEmail(to: string, data: WelcomeTemplateData): Promise<boolean> {
+    return this.sendEmail({
+      to,
+      subject: 'Welcome to Stellar Uzima 🌟',
+      template: 'welcome',
+      data,
+    });
+  }
+
+  async sendPasswordResetEmail(to: string, data: PasswordResetTemplateData): Promise<boolean> {
+    return this.sendEmail({
+      to,
+      subject: 'Reset your Stellar Uzima password',
+      template: 'password-reset',
+      data,
+    });
+  }
+
+  async sendEmailVerification(to: string, data: EmailVerificationTemplateData): Promise<boolean> {
+    return this.sendEmail({
+      to,
+      subject: 'Verify your Stellar Uzima email address',
+      template: 'email-verification',
+      data,
+    });
+  }
+
+  async sendTaskReminder(to: string, data: TaskReminderTemplateData): Promise<boolean> {
+    return this.sendEmail({
+      to,
+      subject: `⏰ You have ${data.pendingCount} task${data.pendingCount !== 1 ? 's' : ''} left today`,
+      template: 'task-reminder',
+      data,
+    });
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Load a template from disk (or from the in-memory cache).
+   */
+  private loadTemplate(name: TemplateName): string {
+    if (this.templateCache.has(name)) {
+      return this.templateCache.get(name)!;
+    }
+
+    const filePath = path.join(this.templateDir, `${name}.html`);
+
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Email template not found: ${name} (expected at ${filePath})`);
+    }
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    this.templateCache.set(name, content);
+    return content;
+  }
+
+  /**
+   * Interpolate `{{variable}}` placeholders and `{{#block}}...{{/block}}`
+   * conditional / loop sections into the template string.
+   */
+  private interpolate(template: string, data: Record<string, unknown>): string {
+    // 1. Handle {{#array}}...{{/array}} loops (iterate over arrays).
+    template = template.replace(
+      /\{\{#(\w+(?:\.\w+)*)\}\}([\s\S]*?)\{\{\/\1\}\}/g,
+      (_, key: string, inner: string) => {
+        const value = this.resolve(data, key);
+        if (Array.isArray(value) && value.length > 0) {
+          return value
+            .map((item: Record<string, unknown>) => this.interpolate(inner, { ...data, ...item }))
+            .join('');
+        }
+        // Truthy non-array: render the block once.
+        if (value && !Array.isArray(value)) {
+          return this.interpolate(inner, data);
+        }
+        return '';
+      },
+    );
+
+    // 2. Replace {{variable}} with escaped values.
+    template = template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_, key: string) => {
+      const value = this.resolve(data, key);
+      return value !== undefined && value !== null ? this.escapeHtml(String(value)) : '';
+    });
+
+    return template;
+  }
+
+  /**
+   * Resolve a dot-notation key path against a data object.
+   * e.g. resolve({ user: { name: 'Alice' } }, 'user.name') → 'Alice'
+   */
+  private resolve(data: Record<string, unknown>, key: string): unknown {
+    return key.split('.').reduce<unknown>((acc, part) => {
+      if (acc && typeof acc === 'object') {
+        return (acc as Record<string, unknown>)[part];
+      }
+      return undefined;
+    }, data);
+  }
+
+  /** Escape HTML special chars to prevent XSS in template data. */
+  private escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#x27;');
+  }
+
+  /** Initialise the nodemailer transporter from environment config. */
+  private initTransporter(): void {
+    const host = this.configService.get<string>('MAIL_HOST');
+    const user = this.configService.get<string>('MAIL_USER');
+    const pass = this.configService.get<string>('MAIL_PASSWORD');
+    const port = parseInt(this.configService.get<string>('MAIL_PORT', '587'), 10);
+
+    if (!host || !user || !pass) {
+      this.logger.warn('Email transporter not initialised: MAIL_HOST, MAIL_USER, MAIL_PASSWORD are required.');
+      return;
+    }
+
+    this.transporter = nodemailer.createTransport({
+      host,
+      port,
+      secure: port === 465,
+      auth: { user, pass },
+    });
+
+    this.logger.log(`Email transporter ready (host=${host} port=${port})`);
+  }
+}

--- a/src/shared/notifications/templates/email-verification.html
+++ b/src/shared/notifications/templates/email-verification.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Verify Your Email — Stellar Uzima</title>
+  <style>
+    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+    img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
+    body { margin: 0; padding: 0; background-color: #f4f7f6; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; }
+
+    .wrapper { width: 100%; background-color: #f4f7f6; padding: 40px 0; }
+    .container { max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 20px rgba(0,0,0,0.08); }
+
+    .header { background: linear-gradient(135deg, #1a7a4a 0%, #25a96a 100%); padding: 40px 40px 32px; text-align: center; }
+    .header h1 { margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px; }
+    .header p { margin: 8px 0 0; color: rgba(255,255,255,0.85); font-size: 15px; }
+
+    .body { padding: 40px; }
+    .icon-wrapper { text-align: center; margin-bottom: 28px; }
+    .icon-circle { display: inline-block; width: 72px; height: 72px; background-color: #e6f7ef; border-radius: 50%; line-height: 72px; font-size: 32px; }
+    .greeting { font-size: 22px; font-weight: 600; color: #1a1a2e; margin: 0 0 16px; }
+    .text { font-size: 15px; line-height: 1.7; color: #4a5568; margin: 0 0 20px; }
+
+    .expiry-badge { display: inline-block; background-color: #e6f7ef; color: #1a7a4a; font-size: 13px; font-weight: 600; padding: 6px 14px; border-radius: 20px; margin-bottom: 24px; }
+
+    .cta-wrapper { text-align: center; margin: 32px 0; }
+    .cta-button { display: inline-block; background: linear-gradient(135deg, #1a7a4a 0%, #25a96a 100%); color: #ffffff !important; text-decoration: none; padding: 16px 40px; border-radius: 8px; font-size: 16px; font-weight: 600; letter-spacing: 0.2px; }
+
+    .link-fallback { background-color: #f9fafb; border-radius: 8px; padding: 16px 20px; margin: 20px 0; }
+    .link-fallback p { margin: 0 0 6px; font-size: 12px; color: #9ca3af; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+    .link-fallback a { font-size: 13px; color: #25a96a; text-decoration: none; word-break: break-all; }
+
+    .why-box { border: 1px solid #e8ecef; border-radius: 8px; padding: 16px 20px; margin: 24px 0; }
+    .why-box p { margin: 0; font-size: 13px; color: #718096; line-height: 1.6; }
+
+    .footer { background-color: #f9fafb; border-top: 1px solid #e8ecef; padding: 28px 40px; text-align: center; }
+    .footer p { margin: 0 0 6px; font-size: 12px; color: #9ca3af; line-height: 1.6; }
+    .footer a { color: #25a96a; text-decoration: none; }
+
+    @media only screen and (max-width: 620px) {
+      .wrapper { padding: 20px 0; }
+      .header { padding: 32px 24px 28px; }
+      .header h1 { font-size: 22px; }
+      .body { padding: 28px 24px; }
+      .footer { padding: 24px; }
+      .cta-button { padding: 14px 28px; font-size: 15px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="container">
+      <!-- Header -->
+      <div class="header">
+        <h1>Stellar Uzima</h1>
+        <p>Confirm your email address</p>
+      </div>
+
+      <!-- Body -->
+      <div class="body">
+        <div class="icon-wrapper">
+          <div class="icon-circle">✉️</div>
+        </div>
+
+        <p class="greeting">Almost there, {{name}}!</p>
+        <p class="text">
+          Thanks for signing up for Stellar Uzima. To start earning rewards and tracking your health goals, please verify your email address by clicking the button below.
+        </p>
+
+        <p style="text-align:center; margin: 0 0 8px;">
+          <span class="expiry-badge">⏱ Link expires in 24 hours</span>
+        </p>
+
+        <div class="cta-wrapper">
+          <a href="{{verificationLink}}" class="cta-button">Verify My Email</a>
+        </div>
+
+        <div class="link-fallback">
+          <p>Button not working? Copy and paste this link:</p>
+          <a href="{{verificationLink}}">{{verificationLink}}</a>
+        </div>
+
+        <div class="why-box">
+          <p>
+            <strong>Why verify?</strong> Verifying your email keeps your account secure and ensures you receive important health task reminders and reward notifications.
+          </p>
+        </div>
+
+        <p class="text" style="font-size: 13px; color: #9ca3af;">
+          If you didn't create a Stellar Uzima account, you can safely ignore this email. No account will be activated without verification.
+        </p>
+      </div>
+
+      <!-- Footer -->
+      <div class="footer">
+        <p>© 2026 Stellar Uzima. All rights reserved.</p>
+        <p>
+          <a href="{{privacyUrl}}">Privacy Policy</a> &nbsp;·&nbsp;
+          <a href="{{unsubscribeUrl}}">Unsubscribe</a>
+        </p>
+        <p>Built with ❤️ on the Stellar network</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/shared/notifications/templates/password-reset.html
+++ b/src/shared/notifications/templates/password-reset.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Reset Your Password — Stellar Uzima</title>
+  <style>
+    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+    img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
+    body { margin: 0; padding: 0; background-color: #f4f7f6; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; }
+
+    .wrapper { width: 100%; background-color: #f4f7f6; padding: 40px 0; }
+    .container { max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 20px rgba(0,0,0,0.08); }
+
+    .header { background: linear-gradient(135deg, #1a7a4a 0%, #25a96a 100%); padding: 40px 40px 32px; text-align: center; }
+    .header h1 { margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px; }
+    .header p { margin: 8px 0 0; color: rgba(255,255,255,0.85); font-size: 15px; }
+
+    .body { padding: 40px; }
+    .icon-wrapper { text-align: center; margin-bottom: 28px; }
+    .icon-circle { display: inline-block; width: 72px; height: 72px; background-color: #fff3cd; border-radius: 50%; line-height: 72px; font-size: 32px; }
+    .greeting { font-size: 22px; font-weight: 600; color: #1a1a2e; margin: 0 0 16px; }
+    .text { font-size: 15px; line-height: 1.7; color: #4a5568; margin: 0 0 20px; }
+
+    .alert-box { background-color: #fff8e1; border-left: 4px solid #f59e0b; border-radius: 0 8px 8px 0; padding: 16px 20px; margin: 24px 0; }
+    .alert-box p { margin: 0; font-size: 13px; color: #92400e; line-height: 1.6; }
+
+    .cta-wrapper { text-align: center; margin: 32px 0; }
+    .cta-button { display: inline-block; background: linear-gradient(135deg, #1a7a4a 0%, #25a96a 100%); color: #ffffff !important; text-decoration: none; padding: 16px 40px; border-radius: 8px; font-size: 16px; font-weight: 600; letter-spacing: 0.2px; }
+
+    .link-fallback { background-color: #f9fafb; border-radius: 8px; padding: 16px 20px; margin: 20px 0; word-break: break-all; }
+    .link-fallback p { margin: 0 0 6px; font-size: 12px; color: #9ca3af; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+    .link-fallback a { font-size: 13px; color: #25a96a; text-decoration: none; word-break: break-all; }
+
+    .footer { background-color: #f9fafb; border-top: 1px solid #e8ecef; padding: 28px 40px; text-align: center; }
+    .footer p { margin: 0 0 6px; font-size: 12px; color: #9ca3af; line-height: 1.6; }
+    .footer a { color: #25a96a; text-decoration: none; }
+
+    @media only screen and (max-width: 620px) {
+      .wrapper { padding: 20px 0; }
+      .header { padding: 32px 24px 28px; }
+      .header h1 { font-size: 22px; }
+      .body { padding: 28px 24px; }
+      .footer { padding: 24px; }
+      .cta-button { padding: 14px 28px; font-size: 15px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="container">
+      <!-- Header -->
+      <div class="header">
+        <h1>Stellar Uzima</h1>
+        <p>Account security</p>
+      </div>
+
+      <!-- Body -->
+      <div class="body">
+        <div class="icon-wrapper">
+          <div class="icon-circle">🔑</div>
+        </div>
+
+        <p class="greeting">Password Reset Request</p>
+        <p class="text">Hi {{name}},</p>
+        <p class="text">
+          We received a request to reset the password for your Stellar Uzima account. Click the button below to choose a new password. This link is valid for <strong>1 hour</strong>.
+        </p>
+
+        <div class="cta-wrapper">
+          <a href="{{resetLink}}" class="cta-button">Reset My Password</a>
+        </div>
+
+        <div class="link-fallback">
+          <p>Button not working? Copy and paste this link:</p>
+          <a href="{{resetLink}}">{{resetLink}}</a>
+        </div>
+
+        <div class="alert-box">
+          <p>
+            <strong>Didn't request this?</strong> If you didn't ask to reset your password, you can safely ignore this email. Your password will remain unchanged and this link will expire automatically.
+          </p>
+        </div>
+
+        <p class="text" style="font-size: 13px; color: #9ca3af;">
+          For your security, this link can only be used once and expires in 1 hour. If you need a new link, visit the login page and click "Forgot password" again.
+        </p>
+      </div>
+
+      <!-- Footer -->
+      <div class="footer">
+        <p>© 2026 Stellar Uzima. All rights reserved.</p>
+        <p>
+          <a href="{{privacyUrl}}">Privacy Policy</a> &nbsp;·&nbsp;
+          <a href="{{unsubscribeUrl}}">Unsubscribe</a>
+        </p>
+        <p>Built with ❤️ on the Stellar network</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/shared/notifications/templates/task-reminder.html
+++ b/src/shared/notifications/templates/task-reminder.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Your Daily Tasks Are Waiting — Stellar Uzima</title>
+  <style>
+    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+    img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
+    body { margin: 0; padding: 0; background-color: #f4f7f6; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; }
+
+    .wrapper { width: 100%; background-color: #f4f7f6; padding: 40px 0; }
+    .container { max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 20px rgba(0,0,0,0.08); }
+
+    .header { background: linear-gradient(135deg, #1a7a4a 0%, #25a96a 100%); padding: 40px 40px 32px; text-align: center; }
+    .header h1 { margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px; }
+    .header p { margin: 8px 0 0; color: rgba(255,255,255,0.85); font-size: 15px; }
+
+    .body { padding: 40px; }
+    .greeting { font-size: 22px; font-weight: 600; color: #1a1a2e; margin: 0 0 16px; }
+    .text { font-size: 15px; line-height: 1.7; color: #4a5568; margin: 0 0 20px; }
+
+    /* Streak banner */
+    .streak-banner { background: linear-gradient(135deg, #f59e0b 0%, #fbbf24 100%); border-radius: 10px; padding: 20px 24px; margin: 0 0 28px; text-align: center; }
+    .streak-banner .streak-number { font-size: 40px; font-weight: 800; color: #ffffff; line-height: 1; }
+    .streak-banner .streak-label { font-size: 13px; color: rgba(255,255,255,0.9); font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 4px; }
+
+    /* Task list */
+    .tasks-section { margin: 24px 0; }
+    .tasks-section h3 { font-size: 14px; font-weight: 700; color: #1a7a4a; text-transform: uppercase; letter-spacing: 0.5px; margin: 0 0 14px; }
+    .task-card { background-color: #f9fafb; border: 1px solid #e8ecef; border-radius: 8px; padding: 14px 16px; margin-bottom: 10px; display: flex; align-items: center; }
+    .task-card:last-child { margin-bottom: 0; }
+    .task-icon { font-size: 20px; margin-right: 14px; flex-shrink: 0; }
+    .task-info { flex: 1; }
+    .task-name { font-size: 14px; font-weight: 600; color: #1a1a2e; margin: 0 0 2px; }
+    .task-reward { font-size: 12px; color: #25a96a; font-weight: 500; }
+
+    .cta-wrapper { text-align: center; margin: 32px 0; }
+    .cta-button { display: inline-block; background: linear-gradient(135deg, #1a7a4a 0%, #25a96a 100%); color: #ffffff !important; text-decoration: none; padding: 16px 40px; border-radius: 8px; font-size: 16px; font-weight: 600; letter-spacing: 0.2px; }
+
+    .motivation { background-color: #f0faf5; border-radius: 8px; padding: 20px 24px; margin: 28px 0; text-align: center; }
+    .motivation p { margin: 0; font-size: 14px; color: #1a7a4a; font-style: italic; line-height: 1.6; }
+
+    .footer { background-color: #f9fafb; border-top: 1px solid #e8ecef; padding: 28px 40px; text-align: center; }
+    .footer p { margin: 0 0 6px; font-size: 12px; color: #9ca3af; line-height: 1.6; }
+    .footer a { color: #25a96a; text-decoration: none; }
+
+    @media only screen and (max-width: 620px) {
+      .wrapper { padding: 20px 0; }
+      .header { padding: 32px 24px 28px; }
+      .header h1 { font-size: 22px; }
+      .body { padding: 28px 24px; }
+      .footer { padding: 24px; }
+      .cta-button { padding: 14px 28px; font-size: 15px; }
+      .streak-banner .streak-number { font-size: 32px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="container">
+      <!-- Header -->
+      <div class="header">
+        <h1>Stellar Uzima</h1>
+        <p>Daily health reminder</p>
+      </div>
+
+      <!-- Body -->
+      <div class="body">
+        <p class="greeting">Hey {{name}}, your tasks are waiting! 🌟</p>
+
+        {{#streakDays}}
+        <div class="streak-banner">
+          <div class="streak-number">🔥 {{streakDays}}</div>
+          <div class="streak-label">Day streak — keep it going!</div>
+        </div>
+        {{/streakDays}}
+
+        <p class="text">
+          You have <strong>{{pendingCount}} task{{#pluralTasks}}s{{/pluralTasks}}</strong> left to complete today. Finish them before midnight to keep your streak alive and earn your rewards.
+        </p>
+
+        {{#tasks.length}}
+        <div class="tasks-section">
+          <h3>Today's pending tasks</h3>
+          {{#tasks}}
+          <div class="task-card">
+            <div class="task-icon">{{icon}}</div>
+            <div class="task-info">
+              <div class="task-name">{{name}}</div>
+              <div class="task-reward">+{{reward}} XLM on completion</div>
+            </div>
+          </div>
+          {{/tasks}}
+        </div>
+        {{/tasks.length}}
+
+        <div class="cta-wrapper">
+          <a href="{{dashboardUrl}}" class="cta-button">Complete My Tasks</a>
+        </div>
+
+        <div class="motivation">
+          <p>"Small consistent actions lead to extraordinary results. You're doing great!"</p>
+        </div>
+
+        <p class="text" style="font-size: 13px; color: #9ca3af;">
+          You're receiving this because you have task reminders enabled. You can manage your notification preferences in your account settings.
+        </p>
+      </div>
+
+      <!-- Footer -->
+      <div class="footer">
+        <p>© 2026 Stellar Uzima. All rights reserved.</p>
+        <p>
+          <a href="{{preferencesUrl}}">Manage Notifications</a> &nbsp;·&nbsp;
+          <a href="{{privacyUrl}}">Privacy Policy</a> &nbsp;·&nbsp;
+          <a href="{{unsubscribeUrl}}">Unsubscribe</a>
+        </p>
+        <p>Built with ❤️ on the Stellar network</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/shared/notifications/templates/welcome.html
+++ b/src/shared/notifications/templates/welcome.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Welcome to Stellar Uzima</title>
+  <style>
+    /* Reset */
+    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+    img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
+    body { margin: 0; padding: 0; background-color: #f4f7f6; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; }
+
+    /* Layout */
+    .wrapper { width: 100%; background-color: #f4f7f6; padding: 40px 0; }
+    .container { max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 20px rgba(0,0,0,0.08); }
+
+    /* Header */
+    .header { background: linear-gradient(135deg, #1a7a4a 0%, #25a96a 100%); padding: 40px 40px 32px; text-align: center; }
+    .header img { width: 48px; height: 48px; margin-bottom: 16px; }
+    .header h1 { margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px; }
+    .header p { margin: 8px 0 0; color: rgba(255,255,255,0.85); font-size: 15px; }
+
+    /* Body */
+    .body { padding: 40px; }
+    .greeting { font-size: 22px; font-weight: 600; color: #1a1a2e; margin: 0 0 16px; }
+    .text { font-size: 15px; line-height: 1.7; color: #4a5568; margin: 0 0 20px; }
+
+    /* Feature list */
+    .features { background-color: #f0faf5; border-radius: 8px; padding: 24px; margin: 28px 0; }
+    .features h3 { margin: 0 0 16px; font-size: 14px; font-weight: 700; color: #1a7a4a; text-transform: uppercase; letter-spacing: 0.5px; }
+    .feature-item { display: flex; align-items: flex-start; margin-bottom: 12px; font-size: 14px; color: #4a5568; }
+    .feature-item:last-child { margin-bottom: 0; }
+    .feature-dot { color: #25a96a; font-size: 18px; line-height: 1.2; margin-right: 10px; flex-shrink: 0; }
+
+    /* CTA */
+    .cta-wrapper { text-align: center; margin: 32px 0; }
+    .cta-button { display: inline-block; background: linear-gradient(135deg, #1a7a4a 0%, #25a96a 100%); color: #ffffff !important; text-decoration: none; padding: 16px 40px; border-radius: 8px; font-size: 16px; font-weight: 600; letter-spacing: 0.2px; }
+
+    /* Footer */
+    .footer { background-color: #f9fafb; border-top: 1px solid #e8ecef; padding: 28px 40px; text-align: center; }
+    .footer p { margin: 0 0 6px; font-size: 12px; color: #9ca3af; line-height: 1.6; }
+    .footer a { color: #25a96a; text-decoration: none; }
+
+    /* Responsive */
+    @media only screen and (max-width: 620px) {
+      .wrapper { padding: 20px 0; }
+      .header { padding: 32px 24px 28px; }
+      .header h1 { font-size: 22px; }
+      .body { padding: 28px 24px; }
+      .footer { padding: 24px; }
+      .cta-button { padding: 14px 28px; font-size: 15px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="container">
+      <!-- Header -->
+      <div class="header">
+        <h1>Stellar Uzima</h1>
+        <p>Your health journey starts today</p>
+      </div>
+
+      <!-- Body -->
+      <div class="body">
+        <p class="greeting">Welcome, {{name}}! 👋</p>
+        <p class="text">
+          We're thrilled to have you join the Stellar Uzima community. You've taken the first step toward a healthier, more rewarding lifestyle — and we're here to support every step of the way.
+        </p>
+
+        <div class="features">
+          <h3>What you can do with Uzima</h3>
+          <div class="feature-item">
+            <span class="feature-dot">✦</span>
+            <span>Complete daily health tasks and build lasting habits</span>
+          </div>
+          <div class="feature-item">
+            <span class="feature-dot">✦</span>
+            <span>Earn XLM rewards for meeting your wellness goals</span>
+          </div>
+          <div class="feature-item">
+            <span class="feature-dot">✦</span>
+            <span>Track your streaks and compete on the leaderboard</span>
+          </div>
+          <div class="feature-item">
+            <span class="feature-dot">✦</span>
+            <span>Get personalized health insights and recommendations</span>
+          </div>
+        </div>
+
+        <p class="text">
+          Your account is all set. Head over to your dashboard to complete your profile and pick up your first daily tasks.
+        </p>
+
+        <div class="cta-wrapper">
+          <a href="{{dashboardUrl}}" class="cta-button">Go to My Dashboard</a>
+        </div>
+
+        <p class="text" style="font-size: 13px; color: #9ca3af;">
+          If you didn't create an account with Stellar Uzima, you can safely ignore this email.
+        </p>
+      </div>
+
+      <!-- Footer -->
+      <div class="footer">
+        <p>© 2026 Stellar Uzima. All rights reserved.</p>
+        <p>
+          <a href="{{privacyUrl}}">Privacy Policy</a> &nbsp;·&nbsp;
+          <a href="{{unsubscribeUrl}}">Unsubscribe</a>
+        </p>
+        <p>Built with ❤️ on the Stellar network</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Closes #664

## Summary
Adds a professional HTML email templating system for all transactational emails on the platform. Previously all emails used plain text or ad-hoc string templates. This PR introduces a centralised `EmailTemplateService`, four responsive HTML templates, and updates the existing email verification flow to use them.

---

## Changes

### New: `src/shared/notifications/templates/`
Four responsive HTML email templates — all include `<meta viewport>` and `@media` queries for mobile rendering:
- `welcome.html` — sent on user registration; features a feature list and dashboard CTA
- `password-reset.html` — includes reset link, 1-hour expiry warning, and "didn't request this?" safety note
- `email-verification.html` — includes verification link, 24-hour expiry badge, and fallback link copy-paste block
- `task-reminder.html` — shows pending task count, streak days, task list with XLM rewards, and motivation block

### New: `src/shared/notifications/services/email-template.service.ts`
- `renderTemplate(template, data)` — loads HTML from disk, interpolates `{{variable}}`, `{{#block}}...{{/block}}` conditionals, and array loops
- `sendEmail(options)` — dispatches via nodemailer transporter (configured from `MAIL_HOST`, `MAIL_PORT`, `MAIL_USER`, `MAIL_PASSWORD` env vars)
- Convenience methods: `sendWelcomeEmail`, `sendPasswordResetEmail`, `sendEmailVerification`, `sendTaskReminder`
- XSS protection: all user-supplied values are HTML-escaped before insertion
- Template caching: templates are read from disk once and cached in memory

### New: `src/shared/notifications/services/email-template.service.spec.ts`
30+ unit tests covering:
- All 4 template files exist on disk and are valid HTML
- All templates contain viewport meta tag and `@media` query (mobile-responsive acceptance criteria)
- Variable interpolation works correctly for each template
- No un-replaced `{{placeholders}}` remain in rendered output
- XSS escaping (`<script>`, `&`, `"`, `'`)
- Template caching returns identical output on repeated calls
- Unknown template throws a clear error
- `sendEmail` returns `false` gracefully when transporter is not configured
- All convenience helpers call `sendEmail` with the correct template name
- Singular/plural subject line logic for task reminder

### Modified: `src/modules/auth/services/email-verification.service.ts`
- Replaced `NotificationService.sendMultiChannel()` call with `EmailTemplateService.sendEmailVerification()`
- Now sends a properly branded HTML email instead of a plain-text fallback

### Modified: `src/modules/auth/auth.module.ts`
- Added `EmailTemplateService` to `providers` and `exports`

### Modified: `package.json`
- Added `nodemailer@^6.9.0` to `dependencies`
- Added `@types/nodemailer@^6.4.0` to `devDependencies`

## Environment variables required
```env
MAIL_HOST=smtp.example.com
MAIL_PORT=587
MAIL_USER=no-reply@stellaruzima.com
MAIL_PASSWORD=your-password
MAIL_FROM_NAME=Stellar Uzima   # optional, defaults to "Stellar Uzima"
FRONTEND_URL=https://app.stellaruzima.com
```
If `MAIL_HOST`, `MAIL_USER`, or `MAIL_PASSWORD` are not set, the transporter gracefully skips sending and logs a warning — no crash.