### PR TITLE
feat: add request tracing and structured log context via RequestIdMiddleware

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
-import { Module } from '@nestjs/common';
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
+import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { ConfigModule } from '@nestjs/config';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { EventEmitterModule } from '@nestjs/event-emitter';
@@ -88,4 +89,8 @@ import { OtpModule } from './otp/otp.module';
     },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(RequestIdMiddleware).forRoutes('*');
+  }
+}

--- a/src/common/middleware/request-id.middleware.spec.ts
+++ b/src/common/middleware/request-id.middleware.spec.ts
@@ -1,0 +1,51 @@
+import { RequestIdMiddleware, REQUEST_ID_HEADER } from './request-id.middleware';
+import { Request, Response } from 'express';
+
+describe('RequestIdMiddleware', () => {
+  let middleware: RequestIdMiddleware;
+
+  beforeEach(() => {
+    middleware = new RequestIdMiddleware();
+  });
+
+  it('should be defined', () => {
+    expect(middleware).toBeDefined();
+  });
+
+  it('should set X-Request-ID header on response', () => {
+    const req = { headers: {} } as Request;
+    const setHeader = jest.fn();
+    const res = { setHeader } as unknown as Response;
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(setHeader).toHaveBeenCalledWith(REQUEST_ID_HEADER, expect.any(String));
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should reuse existing request ID from incoming header', () => {
+    const existingId = 'existing-request-id';
+    const req = { headers: { 'x-request-id': existingId } } as unknown as Request;
+    const setHeader = jest.fn();
+    const res = { setHeader } as unknown as Response;
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(setHeader).toHaveBeenCalledWith(REQUEST_ID_HEADER, existingId);
+    expect((req as any).requestId).toBe(existingId);
+  });
+
+  it('should generate a new UUID when no request ID provided', () => {
+    const req = { headers: {} } as Request;
+    const setHeader = jest.fn();
+    const res = { setHeader } as unknown as Response;
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+
+    const requestId = (req as any).requestId;
+    expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});

--- a/src/common/middleware/request-id.middleware.ts
+++ b/src/common/middleware/request-id.middleware.ts
@@ -1,0 +1,15 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+
+export const REQUEST_ID_HEADER = 'X-Request-ID';
+
+@Injectable()
+export class RequestIdMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction): void {
+    const requestId = (req.headers[REQUEST_ID_HEADER.toLowerCase()] as string) || randomUUID();
+    (req as any).requestId = requestId;
+    res.setHeader(REQUEST_ID_HEADER, requestId);
+    next();
+  }
+}


### PR DESCRIPTION
## Summary

Adds request tracing by generating a unique X-Request-ID for every request, attaching it to the request object for downstream use in logs, and returning it in the response header.

### Changes
- src/common/middleware/request-id.middleware.ts - RequestIdMiddleware generates a UUID per request (or reuses an incoming X-Request-ID), sets eq.requestId, and echoes the ID in the X-Request-ID response header
- src/common/middleware/request-id.middleware.spec.ts - unit tests covering header passthrough, UUID generation, and next() call
- src/app.module.ts - implements NestModule, registers RequestIdMiddleware for all routes via MiddlewareConsumer

closes #725