### PR TITLE
feat(otp): add resend cooldown and abuse prevention

### DIFF
--- a/src/otp/otp-cooldown.spec.ts
+++ b/src/otp/otp-cooldown.spec.ts
@@ -1,0 +1,58 @@
+import { OtpService } from './otp.service';
+
+const redisMock = {
+  exists: jest.fn(),
+  get: jest.fn(),
+  ttl: jest.fn(),
+  setex: jest.fn(),
+  pipeline: jest.fn().mockReturnValue({
+    incr: jest.fn().mockReturnThis(),
+    expire: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue([[null, 1]]),
+  }),
+  del: jest.fn(),
+};
+
+jest.mock('ioredis', () => jest.fn().mockImplementation(() => redisMock));
+jest.mock('../config/redis.config', () => ({
+  redisConfig: jest.fn().mockReturnValue({}),
+  getRedisUrl: jest.fn().mockReturnValue('redis://localhost:6379'),
+}));
+
+const mockConfigService = { get: jest.fn().mockReturnValue(undefined) };
+const mockEventEmitter = { emit: jest.fn() };
+
+describe('OtpService — resend cooldown', () => {
+  let service: OtpService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new OtpService(mockConfigService as any, mockEventEmitter as any);
+  });
+
+  it('should return 429-style response when cooldown is active', async () => {
+    redisMock.exists.mockResolvedValue(0); // not locked
+    redisMock.ttl.mockResolvedValue(45);   // 45s cooldown remaining
+
+    const result = await service.requestOtp('+2348012345678');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('45');
+  });
+
+  it('should allow OTP request when cooldown has expired', async () => {
+    redisMock.exists.mockResolvedValue(0);
+    redisMock.ttl.mockResolvedValue(-2); // key does not exist
+    redisMock.get.mockResolvedValue('1'); // 1 request so far
+    redisMock.setex.mockResolvedValue('OK');
+
+    const result = await service.requestOtp('+2348012345678');
+
+    expect(result.success).toBe(true);
+    expect(redisMock.setex).toHaveBeenCalledWith(
+      expect.stringContaining('otp_resend_cooldown:'),
+      60,
+      '1',
+    );
+  });
+});

--- a/src/otp/otp.service.ts
+++ b/src/otp/otp.service.ts
@@ -34,6 +34,8 @@ export class OtpService {
   private readonly OTP_REQUEST_COUNT_PREFIX = 'otp_requests:';
   private readonly OTP_FAILED_ATTEMPTS_PREFIX = 'otp_failed:';
   private readonly OTP_LOCK_PREFIX = 'otp_lock:';
+  private readonly OTP_RESEND_COOLDOWN_PREFIX = 'otp_resend_cooldown:';
+  private readonly RESEND_COOLDOWN = 60; // 60 seconds between resends
 
   constructor(
     private readonly configService: ConfigService,
@@ -64,6 +66,18 @@ export class OtpService {
       };
     }
 
+    // Check resend cooldown (60 seconds between requests)
+    const cooldownKey = ${this.OTP_RESEND_COOLDOWN_PREFIX}${normalizedPhone};
+    const cooldownTtl = await this.redis.ttl(cooldownKey);
+    if (cooldownTtl > 0) {
+      return {
+        success: false,
+        message: Please wait ${cooldownTtl} second(s) before requesting a new OTP.,
+        remainingAttempts: 0,
+        lockoutMinutes: Math.ceil(cooldownTtl / 60),
+      };
+    }
+
     // Check rate limit (max 3 requests per hour)
     const requestCount = await this.redis.get(requestCountKey);
     const currentCount = requestCount ? parseInt(requestCount, 10) : 0;
@@ -90,6 +104,9 @@ export class OtpService {
     pipeline.incr(requestCountKey);
     pipeline.expire(requestCountKey, this.REQUEST_WINDOW);
     await pipeline.exec();
+
+    // Set resend cooldown
+    await this.redis.setex(cooldownKey, this.RESEND_COOLDOWN, '1');
 
     const newCount = currentCount + 1;
     const remainingAttempts = this.MAX_REQUESTS_PER_HOUR - newCount;


### PR DESCRIPTION
## Summary

Adds a 60-second resend cooldown to `OtpService.requestOtp` to prevent OTP flooding and SMS cost abuse.

### Changes
- `src/otp/otp.service.ts`:
  - Added `OTP_RESEND_COOLDOWN_PREFIX` Redis key prefix and `RESEND_COOLDOWN = 60` constant
  - Added cooldown check at the start of `requestOtp` - returns failure with seconds remaining if cooldown is active
  - Sets cooldown key (60s TTL) after each successful OTP generation
- `src/otp/otp-cooldown.spec.ts` - 2 unit tests: cooldown active returns failure with TTL, expired cooldown allows new request and sets cooldown key

closes #726