### PR TITLE
fix(auth): return 410 Gone for expired password reset tokens

### DIFF
--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -1,13 +1,13 @@
 import {
   BadRequestException,
   ConflictException,
+  GoneException,
   Injectable,
   InternalServerErrorException,
   Logger,
   NotFoundException,
   Optional,
   UnauthorizedException,
-  InternalServerErrorException,
 } from '@nestjs/common';
 import { authenticator } from 'otplib';
 import * as qrcode from 'qrcode';
@@ -537,7 +537,6 @@ export class AuthService {
     await this.usersService.updateLastLogin(user.id);
 
     const tokens = await this.generateTokens(user.id, user.email || user.phoneNumber, user.role);
-    const tokens = await this.generateTokens(user!.id, user!.email || user!.phoneNumber, user!.role);
     return {
       success: true,
       message: 'Authentication successful',
@@ -629,15 +628,19 @@ export class AuthService {
 
   async resetPassword(token: string, newPassword: string) {
     const hash = crypto.createHash('sha256').update(token).digest('hex');
+
+    // Look up by token only — expiry is checked separately so we can return 410
+    // instead of 400 when the token exists but has expired.
     const user = await this.usersService['usersRepository'].findOne({
-      where: {
-        passwordResetToken: hash,
-        passwordResetExpiry: MoreThan(new Date()),
-      },
+      where: { passwordResetToken: hash },
     });
 
     if (!user) {
-      throw new BadRequestException('Invalid or expired reset token');
+      throw new BadRequestException('Invalid reset token');
+    }
+
+    if (!user.passwordResetExpiry || user.passwordResetExpiry <= new Date()) {
+      throw new GoneException('Password reset token has expired');
     }
 
     const hashedPassword = await bcrypt.hash(newPassword, 12);

--- a/src/database/entities/user.entity.ts
+++ b/src/database/entities/user.entity.ts
@@ -110,6 +110,14 @@ export class User {
   @IsString()
   fcmToken?: string | null;
 
+  @Column({ type: 'varchar', length: 255, nullable: true, select: false })
+  @IsOptional()
+  @IsString()
+  passwordResetToken?: string | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  passwordResetExpiry?: Date | null;
+
   @Column({ type: 'int', default: 0 })
   failedLoginAttempts: number;
 

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,10 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { Test, TestingModule } from '@nestjs/testing';
 import { JwtService } from '@nestjs/jwt';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   BadRequestException,
   ConflictException,
+  GoneException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -346,6 +346,57 @@ describe('AuthService', () => {
           country: 'KE',
         }),
       ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('resetPassword', () => {
+    const mockUsersRepository = { findOne: jest.fn() };
+
+    beforeEach(() => {
+      // Wire the internal usersRepository used by resetPassword
+      (mockUsersService as any).usersRepository = mockUsersRepository;
+      mockUsersRepository.findOne.mockReset();
+      mockUsersService.save.mockReset();
+      mockAuditService.logAction.mockReset();
+    });
+
+    it('throws BadRequestException when no user matches the token', async () => {
+      mockUsersRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        authService.resetPassword('invalid-token', 'NewPassword1!'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws GoneException (410) when the reset token has expired', async () => {
+      const expiredUser = {
+        ...baseUser,
+        passwordResetToken: 'hashed-token',
+        passwordResetExpiry: new Date(Date.now() - 1000), // 1 second in the past
+      };
+      mockUsersRepository.findOne.mockResolvedValue(expiredUser);
+
+      await expect(
+        authService.resetPassword('any-token', 'NewPassword1!'),
+      ).rejects.toThrow(GoneException);
+    });
+
+    it('resets the password and clears the token when token is valid', async () => {
+      const validUser = {
+        ...baseUser,
+        passwordResetToken: 'hashed-token',
+        passwordResetExpiry: new Date(Date.now() + 3600 * 1000),
+        password: 'old-hashed',
+      };
+      mockUsersRepository.findOne.mockResolvedValue(validUser);
+      mockUsersService.save.mockImplementation(async (u) => u);
+      mockAuditService.logAction.mockResolvedValue(undefined);
+
+      const result = await authService.resetPassword('valid-token', 'NewPassword1!');
+
+      expect(result).toEqual({ message: 'Password reset successful' });
+      expect(validUser.passwordResetToken).toBeNull();
+      expect(validUser.passwordResetExpiry).toBeNull();
     });
   });
 });

--- a/src/modules/auth/services/email-verification.service.ts
+++ b/src/modules/auth/services/email-verification.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { GoneException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as crypto from 'crypto';
@@ -43,7 +43,9 @@ export class EmailVerificationService {
     const record = await this.repo.findOne({ where: { token }, relations: ['user'] });
     if (!record) return null;
     if (record.consumedAt) return null;
-    if (record.expiresAt < new Date()) return null;
+    if (record.expiresAt < new Date()) {
+      throw new GoneException('Email verification token has expired');
+    }
 
     record.consumedAt = new Date();
     await this.repo.save(record);


### PR DESCRIPTION
Closes #655

## Summary

- **`src/database/entities/user.entity.ts`**: Add `passwordResetToken` and `passwordResetExpiry` columns that were present in `src/auth/entities/user.entity.ts` but missing from the database-layer entity used by the modules
- **`src/modules/auth/services/email-verification.service.ts`**: `consume()` now throws `GoneException` (HTTP 410) instead of silently returning `null` when a token has expired, giving callers a clear signal vs. token-not-found
- **`src/auth/services/auth.service.ts`**: `resetPassword()` now performs a two-step lookup — find by token hash first (without expiry filter), then check expiry separately so expired tokens return `GoneException` (410) while tokens that never existed return `BadRequestException` (400); also fixes pre-existing duplicate `const tokens` declaration
- **`src/modules/auth/auth.service.spec.ts`**: Three new unit tests for `resetPassword`: invalid token (expects 400), expired token (expects 410 GoneException), and successful reset

## Test plan

- [ ] `resetPassword` with unknown token → `BadRequestException` (400)
- [ ] `resetPassword` with expired token → `GoneException` (410) with message "Password reset token has expired"
- [ ] `resetPassword` with valid token within 1-hour window → 200 success, token cleared
- [ ] `forgotPassword` still sets `passwordResetExpiry` to `now + 1h`
- [ ] Email verification token expired → `GoneException` (410) with message "Email verification token has expired"
- [ ] Valid email verification token → consumed and returned as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)