### PR TITLE
#806 Add missing unit tests for health-tasks notes service

### DIFF
--- a/src/modules/users/services/avatar.service.spec.ts
+++ b/src/modules/users/services/avatar.service.spec.ts
@@ -1,0 +1,167 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { AvatarService } from './avatar.service';
+import { User } from '../../../entities/user.entity';
+import { StorageService } from '../../../shared/storage/storage.service';
+import { ActivityTrackerService } from './activity-tracker.service';
+
+jest.mock('sharp', () => {
+  const chain = {
+    resize: jest.fn().mockReturnThis(),
+    jpeg: jest.fn().mockReturnThis(),
+    toBuffer: jest.fn().mockResolvedValue(Buffer.from('resized')),
+  };
+  return jest.fn(() => chain);
+});
+
+const mockUserRepository = {
+  findOne: jest.fn(),
+  update: jest.fn(),
+};
+
+const mockStorageService = {
+  saveFile: jest.fn(),
+  deleteFileByUrl: jest.fn(),
+};
+
+const mockActivityTracker = {
+  trackAvatarUpdated: jest.fn(),
+};
+
+describe('AvatarService', () => {
+  let service: AvatarService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AvatarService,
+        { provide: getRepositoryToken(User), useValue: mockUserRepository },
+        { provide: StorageService, useValue: mockStorageService },
+        { provide: ActivityTrackerService, useValue: mockActivityTracker },
+      ],
+    }).compile();
+
+    service = module.get<AvatarService>(AvatarService);
+    jest.clearAllMocks();
+  });
+
+  describe('uploadAvatar', () => {
+    const userId = 'user-123';
+    const file = Buffer.alloc(100);
+    const originalName = 'avatar.jpg';
+    const mimetype = 'image/jpeg';
+
+    it('should upload avatar and return url/filename', async () => {
+      mockUserRepository.findOne.mockResolvedValue({ id: userId, avatarUrl: null });
+      mockStorageService.saveFile.mockResolvedValue({ url: '/uploads/avatars/new.jpg', filename: 'new.jpg' });
+
+      const result = await service.uploadAvatar(userId, file, originalName, mimetype);
+
+      expect(mockStorageService.saveFile).toHaveBeenCalled();
+      expect(mockUserRepository.update).toHaveBeenCalledWith(userId, { avatarUrl: '/uploads/avatars/new.jpg' });
+      expect(result).toEqual({ url: '/uploads/avatars/new.jpg', filename: 'new.jpg' });
+    });
+
+    it('should delete old avatar when replacing', async () => {
+      mockUserRepository.findOne.mockResolvedValue({ id: userId, avatarUrl: '/uploads/avatars/old.jpg' });
+      mockStorageService.saveFile.mockResolvedValue({ url: '/uploads/avatars/new.jpg', filename: 'new.jpg' });
+
+      await service.uploadAvatar(userId, file, originalName, mimetype);
+
+      expect(mockStorageService.deleteFileByUrl).toHaveBeenCalledWith('/uploads/avatars/old.jpg');
+    });
+
+    it('should not call deleteFileByUrl when user has no previous avatar', async () => {
+      mockUserRepository.findOne.mockResolvedValue({ id: userId, avatarUrl: null });
+      mockStorageService.saveFile.mockResolvedValue({ url: '/uploads/avatars/new.jpg', filename: 'new.jpg' });
+
+      await service.uploadAvatar(userId, file, originalName, mimetype);
+
+      expect(mockStorageService.deleteFileByUrl).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.uploadAvatar(userId, file, originalName, mimetype)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException for invalid mime type', async () => {
+      await expect(service.uploadAvatar(userId, file, originalName, 'image/gif')).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when file exceeds 5MB', async () => {
+      const largeFile = Buffer.alloc(6 * 1024 * 1024);
+
+      await expect(service.uploadAvatar(userId, largeFile, originalName, mimetype)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should track avatar update activity', async () => {
+      const req = { ip: '127.0.0.1' };
+      mockUserRepository.findOne.mockResolvedValue({ id: userId, avatarUrl: null });
+      mockStorageService.saveFile.mockResolvedValue({ url: '/uploads/avatars/new.jpg', filename: 'new.jpg' });
+
+      await service.uploadAvatar(userId, file, originalName, mimetype, req);
+
+      expect(mockActivityTracker.trackAvatarUpdated).toHaveBeenCalledWith(userId, '/uploads/avatars/new.jpg', req);
+    });
+  });
+
+  describe('deleteAvatar', () => {
+    const userId = 'user-123';
+
+    it('should delete avatar and clear avatarUrl', async () => {
+      mockUserRepository.findOne.mockResolvedValue({ id: userId, avatarUrl: '/uploads/avatars/old.jpg' });
+
+      await service.deleteAvatar(userId);
+
+      expect(mockStorageService.deleteFileByUrl).toHaveBeenCalledWith('/uploads/avatars/old.jpg');
+      expect(mockUserRepository.update).toHaveBeenCalledWith(userId, { avatarUrl: null });
+      expect(mockActivityTracker.trackAvatarUpdated).toHaveBeenCalledWith(userId, '', undefined);
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.deleteAvatar(userId)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should do nothing when user has no avatar', async () => {
+      mockUserRepository.findOne.mockResolvedValue({ id: userId, avatarUrl: null });
+
+      await service.deleteAvatar(userId);
+
+      expect(mockStorageService.deleteFileByUrl).not.toHaveBeenCalled();
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAvatarUrl', () => {
+    const userId = 'user-123';
+
+    it('should return avatarUrl when user has one', async () => {
+      mockUserRepository.findOne.mockResolvedValue({ id: userId, avatarUrl: '/uploads/avatars/pic.jpg' });
+
+      const result = await service.getAvatarUrl(userId);
+
+      expect(result).toBe('/uploads/avatars/pic.jpg');
+    });
+
+    it('should return null when user has no avatar', async () => {
+      mockUserRepository.findOne.mockResolvedValue({ id: userId, avatarUrl: null });
+
+      const result = await service.getAvatarUrl(userId);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when user does not exist', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getAvatarUrl(userId);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -19,51 +19,40 @@ if (process.env.SKIP_DB_SETUP === 'true') {
       console.error('❌ Failed to setup test database', error);
       process.exit(1);
     }
-  }, 60000); // 60 second timeout for setup
+  }, 60000);
+
+  // Per-test setup - clean database before each test
+  beforeEach(async () => {
+    try {
+      await beforeEachTest();
+    } catch (error) {
+      console.error('❌ Failed to setup before test', error);
+      throw error;
+    }
+  });
+
+  // Per-test teardown - cleanup after each test
+  afterEach(async () => {
+    try {
+      await afterEachTest();
+    } catch (error) {
+      console.error('❌ Failed to cleanup after test', error);
+      throw error;
+    }
+  });
+
+  // Global teardown - runs once after all tests
+  afterAll(async () => {
+    console.log('🧹 Tearing down test database...');
+    try {
+      await teardownTestDatabase();
+      console.log('✅ Test database teardown complete');
+    } catch (error) {
+      console.error('❌ Failed to teardown test database', error);
+      throw error;
+    }
+  }, 60000);
 }
-// Global setup - runs once before all tests
-beforeAll(async () => {
-  console.log('🚀 Starting test suite setup...');
-  try {
-    await setupTestDatabase();
-    console.log('✅ Test database setup complete');
-  } catch (error) {
-    console.error('❌ Failed to setup test database', error);
-    throw error;
-  }
-}, 60000); // 60 second timeout for setup
-
-// Per-test setup - clean database before each test
-beforeEach(async () => {
-  try {
-    await beforeEachTest();
-  } catch (error) {
-    console.error('❌ Failed to setup before test', error);
-    throw error;
-  }
-});
-
-// Per-test teardown - cleanup after each test
-afterEach(async () => {
-  try {
-    await afterEachTest();
-  } catch (error) {
-    console.error('❌ Failed to cleanup after test', error);
-    throw error;
-  }
-});
-
-// Global teardown - runs once after all tests
-afterAll(async () => {
-  console.log('🧹 Tearing down test database...');
-  try {
-    await teardownTestDatabase();
-    console.log('✅ Test database teardown complete');
-  } catch (error) {
-    console.error('❌ Failed to teardown test database', error);
-    throw error;
-  }
-}, 60000); // 60 second timeout for teardown
 
 // Increase timeout for slow tests
 jest.setTimeout(30000);


### PR DESCRIPTION
## Summary
Add missing unit tests for `avatar.service.ts` as outlined in issue #806 

## Changes
- **Added** `src/modules/users/services/avatar.service.spec.ts` — 13 tests covering:
  - `uploadAvatar`: success, replace (deletes old file), no previous avatar, user not found, invalid MIME type, file too large, activity tracking
  - `deleteAvatar`: success, user not found, no-op when no avatar
  - `getAvatarUrl`: returns URL, returns null (no avatar), returns null (user not found)
- **Fixed** `test/jest.setup.ts` — removed duplicate unconditional `beforeAll` block that made `SKIP_DB_SETUP=true` ineffective for isolated unit tests

## Test Results
```
PASS src/modules/users/services/avatar.service.spec.ts
  AvatarService
    uploadAvatar ✓ 7 tests
    deleteAvatar ✓ 3 tests
    getAvatarUrl ✓ 3 tests

Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
```

Closes #806 