### PR TITLE
test: add unit tests for healer controller, session service, activity-log and bulk task services

### DIFF
--- a/src/auth/healer.controller.spec.ts
+++ b/src/auth/healer.controller.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealerController } from './healer.controller';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { RolesGuard } from './guards/roles.guard';
+
+describe('HealerController', () => {
+  let controller: HealerController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealerController],
+    })
+      .overrideGuard(JwtAuthGuard).useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard).useValue({ canActivate: () => true })
+      .compile();
+    controller = module.get<HealerController>(HealerController);
+  });
+
+  it('should be defined', () => { expect(controller).toBeDefined(); });
+
+  it('getDashboard returns welcome message for healer or admin', () => {
+    expect(controller.getDashboard()).toEqual({ message: 'Welcome healer or admin' });
+  });
+
+  it('getAdmin returns admin-only message', () => {
+    expect(controller.getAdmin()).toEqual({ message: 'Admin only endpoint' });
+  });
+});

--- a/src/modules/auth/services/session.service.spec.ts
+++ b/src/modules/auth/services/session.service.spec.ts
@@ -1,0 +1,47 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SessionService } from './session.service';
+import { Session } from '../../../database/entities/session.entity';
+import { UsersService } from '../../../auth/services/users.service';
+
+describe('SessionService', () => {
+  let service: SessionService;
+  const mockRepo = { create: jest.fn(), save: jest.fn(), find: jest.fn(), findOne: jest.fn() };
+  const mockUsers = { findById: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SessionService,
+        { provide: getRepositoryToken(Session), useValue: mockRepo },
+        { provide: UsersService, useValue: mockUsers },
+      ],
+    }).compile();
+    service = module.get<SessionService>(SessionService);
+  });
+
+  it('should be defined', () => { expect(service).toBeDefined(); });
+
+  it('createSession creates and persists a session', async () => {
+    mockUsers.findById.mockResolvedValue({ id: 'u1' });
+    mockRepo.create.mockReturnValue({ tokenId: 't1', isActive: true });
+    mockRepo.save.mockResolvedValue({ id: 's1', tokenId: 't1' });
+    const result = await service.createSession('u1', 't1', { device: 'web' });
+    expect(mockRepo.save).toHaveBeenCalled();
+    expect(result).toHaveProperty('id', 's1');
+  });
+
+  it('revokeSession sets isActive false and returns true', async () => {
+    const session = { tokenId: 't1', isActive: true };
+    mockRepo.findOne.mockResolvedValue(session);
+    mockRepo.save.mockResolvedValue({ ...session, isActive: false });
+    expect(await service.revokeSession('t1')).toBe(true);
+    expect(session.isActive).toBe(false);
+  });
+
+  it('revokeSession returns false for unknown tokenId', async () => {
+    mockRepo.findOne.mockResolvedValue(null);
+    expect(await service.revokeSession('unknown')).toBe(false);
+  });
+});

--- a/src/modules/health-tasks/services/activity-log.service.spec.ts
+++ b/src/modules/health-tasks/services/activity-log.service.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ActivityLogService } from './activity-log.service';
+import { TaskActivity } from '../../../database/entities/task-activity.entity';
+
+describe('ActivityLogService', () => {
+  let service: ActivityLogService;
+  const mockRepo = { create: jest.fn(), save: jest.fn(), find: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ActivityLogService,
+        { provide: getRepositoryToken(TaskActivity), useValue: mockRepo },
+      ],
+    }).compile();
+    service = module.get<ActivityLogService>(ActivityLogService);
+  });
+
+  it('should be defined', () => { expect(service).toBeDefined(); });
+
+  it('logTaskChange creates and saves an activity entry', async () => {
+    const entry = { taskId: 't1', changedBy: 'u1', changeType: 'status', details: {} };
+    mockRepo.create.mockReturnValue(entry);
+    mockRepo.save.mockResolvedValue({ id: 'a1', ...entry });
+    const result = await service.logTaskChange('t1', 'u1', 'status', {});
+    expect(mockRepo.create).toHaveBeenCalledWith(expect.objectContaining({ taskId: 't1', changedBy: 'u1' }));
+    expect(result).toHaveProperty('id', 'a1');
+  });
+
+  it('getActivityHistory fetches entries with DESC order and pagination', async () => {
+    mockRepo.find.mockResolvedValue([{ id: 'a1' }, { id: 'a2' }]);
+    const result = await service.getActivityHistory('t1', 5, 10);
+    expect(mockRepo.find).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { taskId: 't1' }, order: { createdAt: 'DESC' }, skip: 10, take: 5 }),
+    );
+    expect(result).toHaveLength(2);
+  });
+});

--- a/src/modules/health-tasks/services/bulk.service.spec.ts
+++ b/src/modules/health-tasks/services/bulk.service.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BulkTaskService } from './bulk.service';
+import { HealthTask } from '../../../tasks/entities/health-task.entity';
+import { BadRequestException } from '@nestjs/common';
+
+describe('BulkTaskService', () => {
+  let service: BulkTaskService;
+
+  const mockExec = jest.fn().mockResolvedValue({ affected: 2 });
+  const mockWhereIn = jest.fn().mockReturnValue({ execute: mockExec });
+  const mockSet = jest.fn().mockReturnValue({ whereInIds: mockWhereIn });
+  const mockUpdate = jest.fn().mockReturnValue({ set: mockSet });
+  const mockQb: any = { update: mockUpdate };
+  const mockRepo = {
+    createQueryBuilder: jest.fn(() => mockQb),
+    find: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockSet.mockReturnValue({ whereInIds: mockWhereIn });
+    mockWhereIn.mockReturnValue({ execute: mockExec });
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BulkTaskService,
+        { provide: getRepositoryToken(HealthTask), useValue: mockRepo },
+      ],
+    }).compile();
+    service = module.get<BulkTaskService>(BulkTaskService);
+  });
+
+  it('should be defined', () => { expect(service).toBeDefined(); });
+
+  it('bulkUpdateStatus returns affected count and ids', async () => {
+    const result = await service.bulkUpdateStatus(['id1', 'id2'], 'done');
+    expect(result).toEqual({ affected: 2, ids: ['id1', 'id2'] });
+  });
+
+  it('bulkDelete removes tasks and returns count', async () => {
+    const tasks = [{ id: 'id1' }, { id: 'id2' }];
+    mockRepo.find.mockResolvedValue(tasks);
+    mockRepo.remove.mockResolvedValue(tasks);
+    const result = await service.bulkDelete(['id1', 'id2']);
+    expect(result.affected).toBe(2);
+  });
+
+  it('bulkUpdateStatus throws BadRequestException on empty ids array', async () => {
+    await expect(service.bulkUpdateStatus([], 'done')).rejects.toThrow(BadRequestException);
+  });
+});


### PR DESCRIPTION
## Summary

- **HealerController** (`src/auth/healer.controller.spec.ts`) — overrides `JwtAuthGuard` and `RolesGuard` in test module; verifies `getDashboard` and `getAdmin` return the correct JSON responses.
- **SessionService** (`src/modules/auth/services/session.service.spec.ts`) — mocks `Session` repository and `UsersService`; tests `createSession` persists the session and `revokeSession` toggles `isActive` to `false`.
- **ActivityLogService** (`src/modules/health-tasks/services/activity-log.service.spec.ts`) — mocks `TaskActivity` repository; tests `logTaskChange` calls `create + save` with correct fields and `getActivityHistory` passes `skip/take` pagination.
- **BulkTaskService** (`src/modules/health-tasks/services/bulk.service.spec.ts`) — mocks query builder chain; tests `bulkUpdateStatus`, `bulkDelete`, and empty-ids validation.

closes #822
closes #816
closes #810
closes #811