### PR TITLE
test: add tests for task-notifications, notes controller integration, api-key service and reconcile duplicate api-key

### DIFF
--- a/src/auth/services/api-key.service.ts
+++ b/src/auth/services/api-key.service.ts
@@ -1,0 +1,5 @@
+// #818 – Reconcile duplicate api-key services between auth trees.
+// The full implementation (generateApiKey, validateApiKey, revokeApiKey, getApiKeysByUser)
+// lives in src/modules/auth/services/api-key.service.ts.
+// This re-export points all imports from src/auth/services/ to that single source of truth.
+export { ApiKeyService } from '../../modules/auth/services/api-key.service';

--- a/src/modules/auth/services/api-key.service.spec.ts
+++ b/src/modules/auth/services/api-key.service.spec.ts
@@ -1,0 +1,46 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ApiKeyService } from './api-key.service';
+import { ApiKey } from '../../../database/entities/api-key.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('ApiKeyService (auth module)', () => {
+  let service: ApiKeyService;
+  const mockRepo = { create: jest.fn(), save: jest.fn(), findOne: jest.fn(), find: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApiKeyService,
+        { provide: getRepositoryToken(ApiKey), useValue: mockRepo },
+      ],
+    }).compile();
+    service = module.get<ApiKeyService>(ApiKeyService);
+  });
+
+  it('should be defined', () => { expect(service).toBeDefined(); });
+
+  it('generateApiKey creates and saves a key with 64 hex chars', async () => {
+    mockRepo.create.mockReturnValue({ key: 'abc', userId: 1, scopes: ['read'] });
+    mockRepo.save.mockResolvedValue({ id: 1, key: 'abc' });
+    const result = await service.generateApiKey(1, ['read']);
+    expect(mockRepo.save).toHaveBeenCalled();
+    expect(result).toHaveProperty('key');
+  });
+
+  it('validateApiKey returns null for unknown or revoked key', async () => {
+    mockRepo.findOne.mockResolvedValue(null);
+    expect(await service.validateApiKey('bad')).toBeNull();
+  });
+
+  it('revokeApiKey throws NotFoundException for unknown id', async () => {
+    mockRepo.findOne.mockResolvedValue(null);
+    await expect(service.revokeApiKey(99)).rejects.toThrow(NotFoundException);
+  });
+
+  it('getApiKeysByUser returns all keys for a user', async () => {
+    mockRepo.find.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+    expect(await service.getApiKeysByUser(1)).toHaveLength(2);
+  });
+});

--- a/src/modules/health-tasks/controllers/notes.controller.spec.ts
+++ b/src/modules/health-tasks/controllers/notes.controller.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { NotesController } from './notes.controller';
+import { NotesService } from '../services/notes.service';
+
+describe('NotesController (integration)', () => {
+  let app: INestApplication;
+
+  const mockNotesService = {
+    addNote: jest.fn(),
+    updateNote: jest.fn(),
+    deleteNote: jest.fn(),
+    getNotesByTask: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NotesController],
+      providers: [{ provide: NotesService, useValue: mockNotesService }],
+    }).compile();
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(() => app.close());
+
+  it('GET /tasks/:taskId/notes returns 200 with note list', async () => {
+    mockNotesService.getNotesByTask.mockResolvedValue([{ id: 'n1', content: 'hello' }]);
+    const res = await request(app.getHttpServer()).get('/tasks/t1/notes');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('POST /tasks/:taskId/notes creates a note and returns 201', async () => {
+    mockNotesService.addNote.mockResolvedValue({ id: 'n1', content: 'test note', taskId: 't1' });
+    const res = await request(app.getHttpServer())
+      .post('/tasks/t1/notes')
+      .send({ content: 'test note' });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('id', 'n1');
+  });
+
+  it('DELETE /tasks/:taskId/notes/:noteId returns 200', async () => {
+    mockNotesService.deleteNote.mockResolvedValue(undefined);
+    const res = await request(app.getHttpServer()).delete('/tasks/t1/notes/n1');
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/modules/health-tasks/services/task-notifications.service.spec.ts
+++ b/src/modules/health-tasks/services/task-notifications.service.spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { TaskNotificationsService } from './task-notifications.service';
+import { Notification } from '../../../notifications/entities/notification.entity';
+import { NotificationPreference } from '../../../notifications/entities/notification-preference.entity';
+
+describe('TaskNotificationsService', () => {
+  let service: TaskNotificationsService;
+
+  const mockNotifRepo = { create: jest.fn(), save: jest.fn() };
+  const mockPrefRepo  = { findOne: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TaskNotificationsService,
+        { provide: getRepositoryToken(Notification), useValue: mockNotifRepo },
+        { provide: getRepositoryToken(NotificationPreference), useValue: mockPrefRepo },
+      ],
+    }).compile();
+    service = module.get<TaskNotificationsService>(TaskNotificationsService);
+  });
+
+  it('should be defined', () => { expect(service).toBeDefined(); });
+
+  it('getDeliveryLog returns empty array initially', () => {
+    expect(service.getDeliveryLog('u1')).toEqual([]);
+  });
+
+  it('notifyDueSoon resolves without error', async () => {
+    mockPrefRepo.findOne.mockResolvedValue(null);
+    mockNotifRepo.create.mockReturnValue({});
+    mockNotifRepo.save.mockResolvedValue({ id: 'n1' });
+    const task = { id: 't1', title: 'Walk', xlmReward: 0 } as any;
+    await expect(service.notifyDueSoon(task, 'u1')).resolves.not.toThrow();
+  });
+
+  it('notifyCompleted resolves without error', async () => {
+    mockPrefRepo.findOne.mockResolvedValue(null);
+    mockNotifRepo.create.mockReturnValue({});
+    mockNotifRepo.save.mockResolvedValue({ id: 'n2' });
+    const task = { id: 't2', title: 'Run', xlmReward: 5 } as any;
+    await expect(service.notifyCompleted(task, 'u1')).resolves.not.toThrow();
+  });
+
+  it('notifyOverdue resolves without error', async () => {
+    mockPrefRepo.findOne.mockResolvedValue(null);
+    mockNotifRepo.create.mockReturnValue({});
+    mockNotifRepo.save.mockResolvedValue({ id: 'n3' });
+    const task = { id: 't3', title: 'Overdue task', xlmReward: 0 } as any;
+    await expect(service.notifyOverdue(task, 'u1')).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- **TaskNotificationsService** (`src/modules/health-tasks/services/task-notifications.service.spec.ts`) — mocks `Notification` and `NotificationPreference` repos; tests `getDeliveryLog` returns empty array initially, and `notifyDueSoon`, `notifyCompleted`, `notifyOverdue` all resolve without error.
- **NotesController (integration)** (`src/modules/health-tasks/controllers/notes.controller.spec.ts`) — spins up a `NestApplication` with the controller and a mocked `NotesService`; verifies `GET /tasks/:id/notes` returns 200 with list, `POST` returns 201 with created note, and `DELETE` returns 200.
- **ApiKeyService (auth module)** (`src/modules/auth/services/api-key.service.spec.ts`) — mocks `ApiKey` repo; tests `generateApiKey`, `validateApiKey` returns null for unknown key, `revokeApiKey` throws `NotFoundException`, and `getApiKeysByUser` returns all keys.
- **api-key.service.ts reconcile** (`src/auth/services/api-key.service.ts`) — replaces the stub-only implementation with a re-export from `src/modules/auth/services/api-key.service.ts`, eliminating the duplicate between the two auth trees.

closes #812
closes #813
closes #817
closes #818