### PR TITLE
test(health-tasks): add unit tests for reminder scheduling and dispatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1906,7 +1906,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -4621,7 +4620,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
       "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4634,7 +4632,6 @@
       "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
       "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
       "deprecated": "This functionality has been moved to @npmcli/fs",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4650,7 +4647,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4672,7 +4668,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -4687,7 +4682,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -6607,7 +6601,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -6702,7 +6695,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6716,7 +6708,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6866,7 +6857,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
       "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -6875,7 +6865,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
       "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7234,7 +7223,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7391,7 +7380,6 @@
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
       "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7423,7 +7411,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7445,7 +7432,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7459,7 +7445,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7473,7 +7458,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -7488,7 +7472,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -7505,7 +7488,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -7742,7 +7724,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7879,7 +7860,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -7934,7 +7914,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -7961,7 +7941,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -8300,7 +8279,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -8555,7 +8533,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8566,7 +8543,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9656,7 +9632,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -9692,7 +9668,6 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
       "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -9713,7 +9688,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -10176,7 +10150,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -10276,7 +10250,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -10336,7 +10309,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true
     },
@@ -10407,7 +10379,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10491,7 +10462,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -10500,7 +10471,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -10511,7 +10481,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -10520,7 +10489,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -10607,7 +10576,6 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -10716,7 +10684,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -13212,7 +13179,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
       "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13241,7 +13207,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -13252,7 +13217,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13268,7 +13232,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13282,7 +13245,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13296,7 +13258,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -13446,7 +13407,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -13477,7 +13438,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
       "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13491,7 +13451,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13505,7 +13464,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -13513,7 +13471,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
       "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13532,7 +13489,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13546,7 +13502,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -13554,7 +13509,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
       "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {
@@ -13568,7 +13522,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13582,7 +13535,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -13590,7 +13542,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13604,7 +13555,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13618,7 +13568,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -13626,7 +13575,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13640,7 +13588,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13654,7 +13601,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -13878,7 +13824,6 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
       "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13921,7 +13866,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13944,7 +13888,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13973,7 +13916,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14011,7 +13953,6 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
       "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14175,7 +14116,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14309,7 +14249,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14740,7 +14680,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -14748,7 +14687,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14763,7 +14701,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -15822,7 +15759,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -15834,7 +15770,6 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
       "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -15850,7 +15785,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
       "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -15949,7 +15883,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
       "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15963,7 +15896,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15977,7 +15909,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -17266,7 +17197,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -17277,7 +17207,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -17675,7 +17604,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {

--- a/src/modules/health-tasks/services/reminder.service.spec.ts
+++ b/src/modules/health-tasks/services/reminder.service.spec.ts
@@ -1,0 +1,341 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { Repository, LessThanOrEqual } from 'typeorm';
+import { ReminderService } from './reminder.service';
+import { TaskReminder, ReminderStatus, ReminderType } from '../../../database/entities/task-reminder.entity';
+import { NotificationService } from '../../../notifications/services/notification.service';
+import { HealthTask } from '../../../entities/health-task.entity';
+
+describe('ReminderService', () => {
+  let service: ReminderService;
+  let reminderRepo: Repository<TaskReminder>;
+  let taskRepo: Repository<HealthTask>;
+  let notificationService: NotificationService;
+
+  const mockReminderRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const mockTaskRepo = {
+    findOne: jest.fn(),
+  };
+
+  const mockNotificationService = {
+    sendEmail: jest.fn(),
+    sendSMS: jest.fn(),
+    sendPush: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReminderService,
+        {
+          provide: getRepositoryToken(TaskReminder),
+          useValue: mockReminderRepo,
+        },
+        {
+          provide: getRepositoryToken(HealthTask),
+          useValue: mockTaskRepo,
+        },
+        {
+          provide: NotificationService,
+          useValue: mockNotificationService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ReminderService>(ReminderService);
+    reminderRepo = module.get<Repository<TaskReminder>>(
+      getRepositoryToken(TaskReminder),
+    );
+    taskRepo = module.get<Repository<HealthTask>>(
+      getRepositoryToken(HealthTask),
+    );
+    notificationService = module.get<NotificationService>(NotificationService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('setReminder', () => {
+    const taskId = 'task-1';
+    const userId = 'user-1';
+    const remindAt = new Date('2026-06-28T10:00:00Z');
+
+    it('should create a reminder with default type (PUSH)', async () => {
+      const mockTask = { id: taskId, title: 'Test Task' };
+      const mockReminder = {
+        id: 'reminder-1',
+        taskId,
+        userId,
+        remindAt,
+        type: ReminderType.PUSH,
+        status: ReminderStatus.SCHEDULED,
+      };
+
+      mockTaskRepo.findOne.mockResolvedValue(mockTask);
+      mockReminderRepo.create.mockReturnValue(mockReminder);
+      mockReminderRepo.save.mockResolvedValue(mockReminder);
+
+      const result = await service.setReminder(taskId, userId, remindAt);
+
+      expect(result).toEqual(mockReminder);
+      expect(mockTaskRepo.findOne).toHaveBeenCalledWith({ where: { id: taskId } });
+      expect(mockReminderRepo.create).toHaveBeenCalledWith({
+        taskId,
+        userId,
+        remindAt,
+        type: ReminderType.PUSH,
+        status: ReminderStatus.SCHEDULED,
+      });
+      expect(mockReminderRepo.save).toHaveBeenCalledWith(mockReminder);
+    });
+
+    it('should create a reminder with specified type', async () => {
+      const mockTask = { id: taskId, title: 'Test Task' };
+      const mockReminder = {
+        id: 'reminder-1',
+        taskId,
+        userId,
+        remindAt,
+        type: ReminderType.EMAIL,
+        status: ReminderStatus.SCHEDULED,
+      };
+
+      mockTaskRepo.findOne.mockResolvedValue(mockTask);
+      mockReminderRepo.create.mockReturnValue(mockReminder);
+      mockReminderRepo.save.mockResolvedValue(mockReminder);
+
+      const result = await service.setReminder(taskId, userId, remindAt, ReminderType.EMAIL);
+
+      expect(result.type).toBe(ReminderType.EMAIL);
+      expect(mockReminderRepo.create).toHaveBeenCalledWith({
+        taskId,
+        userId,
+        remindAt,
+        type: ReminderType.EMAIL,
+        status: ReminderStatus.SCHEDULED,
+      });
+    });
+
+    it('should throw NotFoundException if task does not exist', async () => {
+      mockTaskRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.setReminder(taskId, userId, remindAt),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('cancelReminder', () => {
+    it('should cancel a scheduled reminder', async () => {
+      const reminder = {
+        id: 'reminder-1',
+        status: ReminderStatus.SCHEDULED,
+      };
+
+      mockReminderRepo.findOne.mockResolvedValue(reminder);
+      mockReminderRepo.save.mockResolvedValue({ ...reminder, status: ReminderStatus.CANCELLED });
+
+      await service.cancelReminder('reminder-1');
+
+      expect(reminder.status).toBe(ReminderStatus.CANCELLED);
+      expect(mockReminderRepo.save).toHaveBeenCalledWith(reminder);
+    });
+
+    it('should throw NotFoundException if reminder does not exist', async () => {
+      mockReminderRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.cancelReminder('missing-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('processDueReminders', () => {
+    const baseReminder = (overrides: Partial<TaskReminder> = {}): TaskReminder => ({
+      id: 'reminder-1',
+      taskId: 'task-1',
+      userId: 'user-1',
+      remindAt: new Date('2026-06-27T00:00:00Z'),
+      type: ReminderType.PUSH,
+      status: ReminderStatus.SCHEDULED,
+      deliveryTracking: null,
+      task: { id: 'task-1', title: 'Test Task' } as HealthTask,
+      user: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      ...overrides,
+    });
+
+    it('should find and process due reminders', async () => {
+      const dueReminders = [baseReminder()];
+      mockReminderRepo.find.mockResolvedValue(dueReminders);
+      mockNotificationService.sendPush.mockResolvedValue(true);
+      mockReminderRepo.save.mockImplementation(async (r) => r);
+
+      const processedCount = await service.processDueReminders();
+
+      expect(processedCount).toBe(1);
+      expect(mockReminderRepo.find).toHaveBeenCalledWith({
+        where: {
+          status: ReminderStatus.SCHEDULED,
+          remindAt: LessThanOrEqual(expect.any(Date)),
+        },
+        relations: ['task'],
+      });
+      expect(mockNotificationService.sendPush).toHaveBeenCalledWith(
+        'user-1',
+        'Task Reminder',
+        'Time to work on your task: Test Task',
+      );
+    });
+
+    it('should dispatch EMAIL reminders via notificationService.sendEmail', async () => {
+      const emailReminder = baseReminder({
+        id: 'reminder-email',
+        type: ReminderType.EMAIL,
+      });
+      mockReminderRepo.find.mockResolvedValue([emailReminder]);
+      mockNotificationService.sendEmail.mockResolvedValue(true);
+      mockReminderRepo.save.mockImplementation(async (r) => r);
+
+      await service.processDueReminders();
+
+      expect(mockNotificationService.sendEmail).toHaveBeenCalledWith(
+        'user-1',
+        'task-reminder',
+        {
+          taskTitle: 'Test Task',
+          remindAt: emailReminder.remindAt,
+        },
+      );
+    });
+
+    it('should dispatch SMS reminders via notificationService.sendSMS', async () => {
+      const smsReminder = baseReminder({
+        id: 'reminder-sms',
+        type: ReminderType.SMS,
+      });
+      mockReminderRepo.find.mockResolvedValue([smsReminder]);
+      mockNotificationService.sendSMS.mockResolvedValue(true);
+      mockReminderRepo.save.mockImplementation(async (r) => r);
+
+      await service.processDueReminders();
+
+      expect(mockNotificationService.sendSMS).toHaveBeenCalledWith(
+        'user-1',
+        'Reminder: Your health task "Test Task" is due now!',
+      );
+    });
+
+    it('should fall back to "Health Task" title when task is missing', async () => {
+      const reminderNoTask = baseReminder({ task: null });
+      mockReminderRepo.find.mockResolvedValue([reminderNoTask]);
+      mockNotificationService.sendPush.mockResolvedValue(true);
+      mockReminderRepo.save.mockImplementation(async (r) => r);
+
+      await service.processDueReminders();
+
+      expect(mockNotificationService.sendPush).toHaveBeenCalledWith(
+        'user-1',
+        'Task Reminder',
+        'Time to work on your task: Health Task',
+      );
+    });
+
+    it('should mark reminder as SENT on successful dispatch', async () => {
+      const reminder = baseReminder();
+      mockReminderRepo.find.mockResolvedValue([reminder]);
+      mockNotificationService.sendPush.mockResolvedValue(true);
+      mockReminderRepo.save.mockImplementation(async (r) => r);
+
+      await service.processDueReminders();
+
+      expect(reminder.status).toBe(ReminderStatus.SENT);
+      expect(reminder.deliveryTracking).toEqual({
+        sentAt: expect.any(Date),
+        status: 'delivered',
+      });
+    });
+
+    it('should mark reminder as FAILED when notification service returns false', async () => {
+      const reminder = baseReminder();
+      mockReminderRepo.find.mockResolvedValue([reminder]);
+      mockNotificationService.sendPush.mockResolvedValue(false);
+      mockReminderRepo.save.mockImplementation(async (r) => r);
+
+      await service.processDueReminders();
+
+      expect(reminder.status).toBe(ReminderStatus.FAILED);
+      expect(reminder.deliveryTracking).toEqual({
+        sentAt: expect.any(Date),
+        status: 'failed_by_notification_service',
+      });
+    });
+
+    it('should handle exceptions during send and mark reminder as FAILED with error tracking', async () => {
+      const reminder = baseReminder();
+      mockReminderRepo.find.mockResolvedValue([reminder]);
+      mockNotificationService.sendPush.mockRejectedValue(new Error('Network error'));
+      mockReminderRepo.save.mockImplementation(async (r) => r);
+
+      const processedCount = await service.processDueReminders();
+
+      expect(processedCount).toBe(0);
+      expect(reminder.status).toBe(ReminderStatus.FAILED);
+      expect(reminder.deliveryTracking).toEqual({
+        error: 'Network error',
+        timestamp: expect.any(Date),
+      });
+    });
+
+    it('should return 0 when no due reminders exist', async () => {
+      mockReminderRepo.find.mockResolvedValue([]);
+
+      const result = await service.processDueReminders();
+
+      expect(result).toBe(0);
+      expect(mockNotificationService.sendPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getRemindersForTask', () => {
+    it('should return reminders for a task ordered by remindAt ascending', async () => {
+      const reminders = [
+        { id: 'r1', taskId: 'task-1', remindAt: new Date('2026-06-27T10:00:00Z') },
+        { id: 'r2', taskId: 'task-1', remindAt: new Date('2026-06-28T10:00:00Z') },
+      ];
+
+      mockReminderRepo.find.mockResolvedValue(reminders);
+
+      const result = await service.getRemindersForTask('task-1');
+
+      expect(result).toEqual(reminders);
+      expect(mockReminderRepo.find).toHaveBeenCalledWith({
+        where: { taskId: 'task-1' },
+        order: { remindAt: 'ASC' },
+      });
+    });
+  });
+
+  describe('deleteReminder', () => {
+    it('should delete a reminder by ID', async () => {
+      mockReminderRepo.delete.mockResolvedValue({ affected: 1, raw: {} });
+
+      await service.deleteReminder('reminder-1');
+
+      expect(mockReminderRepo.delete).toHaveBeenCalledWith('reminder-1');
+    });
+  });
+});


### PR DESCRIPTION
Close #801 

PR Description
## Summary

Adds unit tests for `reminder.service.ts` in the health-tasks module. No spec file existed despite other services (analytics, completion, priority, archive) having full coverage.

## Changes

- **New:** `src/modules/health-tasks/services/reminder.service.spec.ts` (16 tests)

### Test Coverage

| Method | Scenarios |
|---|---|
| `setReminder` | Default PUSH type, custom EMAIL type, NotFoundException for missing task |
| `cancelReminder` | Successful cancellation, NotFoundException for missing reminder |
| `processDueReminders` | EMAIL/SMS/PUSH dispatch paths, fallback title when task is null, SENT status on success, FAILED on delivery failure, exception handling with error tracking, zero reminders edge case |
| `getRemindersForTask` | Returns reminders ordered by remindAt ascending |
| `deleteReminder` | Delegates to repository.delete |

## How to Test

```bash
SKIP_DB_SETUP=true npm run test -- reminder
All 16 tests pass.
