### PR TITLE
feat: distinguish Ed25519 and Smart Wallet authorization types

### DIFF
--- a/src/stellar/README.md
+++ b/src/stellar/README.md
@@ -1,0 +1,85 @@
+# Stellar Module
+
+Utilities for Stellar/Soroban network interactions used by the Uzima backend.
+
+## Services
+
+| Service | Description |
+|---|---|
+| `StellarService` | Account existence checks and balance queries via Horizon |
+| `PriceFeedService` | XLM/USD price feed with caching |
+| `XlmPriceService` | XLM price helper |
+| `SorobanAuthService` | Soroban authorization type detection (Ed25519 vs Smart Wallet) |
+
+---
+
+## SorobanAuthService
+
+Decodes a base64-encoded `SorobanAuthorizationEntry` XDR and determines whether it
+carries an **Ed25519** or **Smart Wallet** authorization.
+
+### Supported Authorization Types
+
+| Type | Credential | Description |
+|---|---|---|
+| `Ed25519` | `sorobanCredentialsSourceAccount` | Classic Stellar source-account signature |
+| `Ed25519` | `sorobanCredentialsAddress` → `scAddressTypeAccount` | Ed25519 key wrapped in an address credential |
+| `SmartWallet` | `sorobanCredentialsAddress` → `scAddressTypeContract` | Contract acts as the signer |
+
+### Detection Logic
+
+1. Decode the XDR using `xdr.SorobanAuthorizationEntry.fromXDR(payload, 'base64')`.
+2. Inspect `credentials().switch().name`:
+   - `'sorobanCredentialsSourceAccount'` → **Ed25519** (no address info).
+   - `'sorobanCredentialsAddress'` → examine the nested `ScAddress`:
+     - `scAddressTypeAccount` → **Ed25519**, public key extracted via `StrKey.encodeEd25519PublicKey`.
+     - `scAddressTypeContract` → **SmartWallet**, contract ID extracted via `StrKey.encodeContract`.
+3. Any other credential type or malformed XDR throws an `Error`.
+
+### API
+
+```typescript
+interface SorobanAuthResult {
+  authorizationType: 'Ed25519' | 'SmartWallet';
+  publicKey?: string;              // G… Stellar address (Ed25519 only)
+  contractId?: string;             // C… contract address (SmartWallet only)
+  signatureExpirationLedger?: number;
+}
+
+service.decodeAuthorizationEntry(authEntryXdrBase64: string): SorobanAuthResult
+```
+
+### Output Examples
+
+**Ed25519 (source-account)**
+```json
+{
+  "authorizationType": "Ed25519"
+}
+```
+
+**Ed25519 (address credential)**
+```json
+{
+  "authorizationType": "Ed25519",
+  "publicKey": "GCFYRR57USYMII3FM4LIBNGIWPRA55LF7SOT52IQ5XCZMHBZQTDD7FHW",
+  "signatureExpirationLedger": 1000
+}
+```
+
+**Smart Wallet**
+```json
+{
+  "authorizationType": "SmartWallet",
+  "contractId": "CDPN5XW633PN5XW633PN5XW633PN5XW633PN5XW633PN5XW633PN4I4N",
+  "signatureExpirationLedger": 2000
+}
+```
+
+### Error Handling
+
+| Condition | Thrown message |
+|---|---|
+| Empty or non-string input | `Invalid authorization payload: must be a non-empty string` |
+| XDR decode failure | `Malformed authorization payload: failed to decode XDR` |
+| Unknown credential type | `Unknown authorization credential type: <name>` |

--- a/src/stellar/soroban-auth.service.spec.ts
+++ b/src/stellar/soroban-auth.service.spec.ts
@@ -1,0 +1,162 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SorobanAuthService } from './soroban-auth.service';
+
+// Real XDR fixtures generated with stellar-sdk xdr builders.
+// See scripts/generate-test-fixtures.ts for reproduction steps.
+
+/**
+ * SorobanAuthorizationEntry with sorobanCredentialsSourceAccount:
+ * classic Ed25519 — no address credentials, just the source account.
+ */
+const SRC_ACCOUNT_XDR =
+  'AAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEdGVzdAAAAAAAAAAA';
+
+/**
+ * SorobanAuthorizationEntry with sorobanCredentialsAddress (scAddressTypeAccount):
+ * Ed25519 key wrapped in an address credential.
+ * Public key: GCFYRR57USYMII3FM4LIBNGIWPRA55LF7SOT52IQ5XCZMHBZQTDD7FHW
+ * signatureExpirationLedger: 1000
+ */
+const ADDR_ACCOUNT_XDR =
+  'AAAAAQAAAAAAAAAAi4jHv6SwxCNlZxaAtMiz4g71ZfydPukQ7cWWHDmExj8AAAAAAAAwOQAAA+gAAAABAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAR0ZXN0AAAAAAAAAAA=';
+const ADDR_ACCOUNT_PUBKEY = 'GCFYRR57USYMII3FM4LIBNGIWPRA55LF7SOT52IQ5XCZMHBZQTDD7FHW';
+
+/**
+ * SorobanAuthorizationEntry with sorobanCredentialsAddress (scAddressTypeContract):
+ * Smart Wallet — a contract acts as the signer.
+ * Contract ID: CDPN5XW633PN5XW633PN5XW633PN5XW633PN5XW633PN5XW633PN4I4N
+ * signatureExpirationLedger: 2000
+ */
+const SMART_WALLET_XDR =
+  'AAAAAQAAAAHe3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3gAAAAAAAYafAAAH0AAAAAEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABGNhbGwAAAAAAAAAAA==';
+const SMART_WALLET_CONTRACT_ID =
+  'CDPN5XW633PN5XW633PN5XW633PN5XW633PN5XW633PN5XW633PN4I4N';
+
+describe('SorobanAuthService', () => {
+  let service: SorobanAuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SorobanAuthService],
+    }).compile();
+
+    service = module.get<SorobanAuthService>(SorobanAuthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ─── Ed25519 source-account credential ────────────────────────────────────
+
+  describe('sorobanCredentialsSourceAccount (classic Ed25519)', () => {
+    it('detects authorization type as Ed25519', () => {
+      const result = service.decodeAuthorizationEntry(SRC_ACCOUNT_XDR);
+      expect(result.authorizationType).toBe('Ed25519');
+    });
+
+    it('does not include a publicKey for source-account credentials', () => {
+      const result = service.decodeAuthorizationEntry(SRC_ACCOUNT_XDR);
+      expect(result.publicKey).toBeUndefined();
+    });
+
+    it('does not include a contractId', () => {
+      const result = service.decodeAuthorizationEntry(SRC_ACCOUNT_XDR);
+      expect(result.contractId).toBeUndefined();
+    });
+  });
+
+  // ─── Ed25519 address credential ───────────────────────────────────────────
+
+  describe('sorobanCredentialsAddress with scAddressTypeAccount (Ed25519)', () => {
+    it('detects authorization type as Ed25519', () => {
+      const result = service.decodeAuthorizationEntry(ADDR_ACCOUNT_XDR);
+      expect(result.authorizationType).toBe('Ed25519');
+    });
+
+    it('returns the correct Ed25519 public key', () => {
+      const result = service.decodeAuthorizationEntry(ADDR_ACCOUNT_XDR);
+      expect(result.publicKey).toBe(ADDR_ACCOUNT_PUBKEY);
+    });
+
+    it('does not include a contractId', () => {
+      const result = service.decodeAuthorizationEntry(ADDR_ACCOUNT_XDR);
+      expect(result.contractId).toBeUndefined();
+    });
+
+    it('returns the signatureExpirationLedger', () => {
+      const result = service.decodeAuthorizationEntry(ADDR_ACCOUNT_XDR);
+      expect(result.signatureExpirationLedger).toBe(1000);
+    });
+  });
+
+  // ─── Smart Wallet credential ──────────────────────────────────────────────
+
+  describe('sorobanCredentialsAddress with scAddressTypeContract (Smart Wallet)', () => {
+    it('detects authorization type as SmartWallet', () => {
+      const result = service.decodeAuthorizationEntry(SMART_WALLET_XDR);
+      expect(result.authorizationType).toBe('SmartWallet');
+    });
+
+    it('returns the correct contract ID', () => {
+      const result = service.decodeAuthorizationEntry(SMART_WALLET_XDR);
+      expect(result.contractId).toBe(SMART_WALLET_CONTRACT_ID);
+    });
+
+    it('does not include a publicKey', () => {
+      const result = service.decodeAuthorizationEntry(SMART_WALLET_XDR);
+      expect(result.publicKey).toBeUndefined();
+    });
+
+    it('returns the signatureExpirationLedger', () => {
+      const result = service.decodeAuthorizationEntry(SMART_WALLET_XDR);
+      expect(result.signatureExpirationLedger).toBe(2000);
+    });
+  });
+
+  // ─── Authorization type detection correctness ─────────────────────────────
+
+  describe('authorization type detection', () => {
+    it('correctly distinguishes Ed25519 source-account from SmartWallet', () => {
+      const ed25519 = service.decodeAuthorizationEntry(SRC_ACCOUNT_XDR);
+      const smartWallet = service.decodeAuthorizationEntry(SMART_WALLET_XDR);
+      expect(ed25519.authorizationType).not.toBe(smartWallet.authorizationType);
+    });
+
+    it('Ed25519 address credential produces the same type as source-account', () => {
+      const srcAccount = service.decodeAuthorizationEntry(SRC_ACCOUNT_XDR);
+      const addrAccount = service.decodeAuthorizationEntry(ADDR_ACCOUNT_XDR);
+      expect(srcAccount.authorizationType).toBe(addrAccount.authorizationType);
+    });
+  });
+
+  // ─── Error handling ───────────────────────────────────────────────────────
+
+  describe('invalid / malformed payloads', () => {
+    it('throws on empty string', () => {
+      expect(() => service.decodeAuthorizationEntry('')).toThrow(
+        'Invalid authorization payload',
+      );
+    });
+
+    it('throws on null-like input', () => {
+      expect(() => service.decodeAuthorizationEntry(null as any)).toThrow(
+        'Invalid authorization payload',
+      );
+    });
+
+    it('throws on random non-XDR base64', () => {
+      expect(() =>
+        service.decodeAuthorizationEntry(
+          Buffer.from('not-xdr-data-at-all').toString('base64'),
+        ),
+      ).toThrow('Malformed authorization payload');
+    });
+
+    it('throws on plain text', () => {
+      expect(() =>
+        service.decodeAuthorizationEntry('hello world'),
+      ).toThrow('Malformed authorization payload');
+    });
+  });
+});

--- a/src/stellar/soroban-auth.service.ts
+++ b/src/stellar/soroban-auth.service.ts
@@ -1,0 +1,94 @@
+import { Injectable, Logger } from '@nestjs/common';
+import StellarSdk from 'stellar-sdk';
+
+/** The two supported Soroban authorization types. */
+export type SorobanAuthType = 'Ed25519' | 'SmartWallet';
+
+export interface SorobanAuthResult {
+  /** Detected authorization type. */
+  authorizationType: SorobanAuthType;
+  /** Ed25519 public key (G… address) — present when authorizationType is 'Ed25519'. */
+  publicKey?: string;
+  /** Smart Wallet contract ID (C… address) — present when authorizationType is 'SmartWallet'. */
+  contractId?: string;
+  /** Signature expiration ledger from the credentials, if available. */
+  signatureExpirationLedger?: number;
+}
+
+@Injectable()
+export class SorobanAuthService {
+  private readonly logger = new Logger(SorobanAuthService.name);
+  private readonly xdr = (StellarSdk as any).xdr;
+  private readonly StrKey = (StellarSdk as any).StrKey;
+
+  /**
+   * Detects whether a base64-encoded SorobanAuthorizationEntry uses an
+   * Ed25519 (source-account) or Smart Wallet (contract address) credential,
+   * and returns the decoded details.
+   *
+   * @param authEntryXdrBase64  Base64-encoded XDR of a SorobanAuthorizationEntry
+   * @throws Error for unknown or malformed payloads
+   */
+  decodeAuthorizationEntry(authEntryXdrBase64: string): SorobanAuthResult {
+    if (!authEntryXdrBase64 || typeof authEntryXdrBase64 !== 'string') {
+      throw new Error('Invalid authorization payload: must be a non-empty string');
+    }
+
+    let entry: any;
+    try {
+      entry = this.xdr.SorobanAuthorizationEntry.fromXDR(
+        authEntryXdrBase64,
+        'base64',
+      );
+    } catch {
+      throw new Error('Malformed authorization payload: failed to decode XDR');
+    }
+
+    const credentials: any = entry.credentials();
+    const credentialsType = credentials.switch();
+
+    if (credentialsType.name === 'sorobanCredentialsSourceAccount') {
+      // Ed25519: the source account signs with its ed25519 key
+      this.logger.debug('Detected Ed25519 authorization');
+      return { authorizationType: 'Ed25519' };
+    }
+
+    if (credentialsType.name === 'sorobanCredentialsAddress') {
+      const addressCredentials: any = credentials.address();
+      const scAddress: any = addressCredentials.address();
+      const addressType = scAddress.switch();
+      const expirationLedger: number = addressCredentials.signatureExpirationLedger();
+
+      if (addressType.name === 'scAddressTypeAccount') {
+        // Ed25519 public key wrapped in an address credential
+        const accountId: any = scAddress.accountId();
+        const publicKey: string = this.StrKey.encodeEd25519PublicKey(
+          accountId.ed25519(),
+        );
+        this.logger.debug('Detected Ed25519 address authorization');
+        return {
+          authorizationType: 'Ed25519',
+          publicKey,
+          signatureExpirationLedger: expirationLedger,
+        };
+      }
+
+      if (addressType.name === 'scAddressTypeContract') {
+        // Smart Wallet: a contract acts as the signer
+        const contractId: string = this.StrKey.encodeContract(
+          scAddress.contractId(),
+        );
+        this.logger.debug('Detected Smart Wallet authorization, contractId=%s', contractId);
+        return {
+          authorizationType: 'SmartWallet',
+          contractId,
+          signatureExpirationLedger: expirationLedger,
+        };
+      }
+    }
+
+    throw new Error(
+      `Unknown authorization credential type: ${credentialsType.name}`,
+    );
+  }
+}

--- a/src/stellar/stellar.module.ts
+++ b/src/stellar/stellar.module.ts
@@ -3,10 +3,11 @@ import { StellarService } from './stellar.service';
 import { StellarController } from './stellar.controller';
 import { XlmPriceService } from './xlm-price.service';
 import { PriceFeedService } from './price-feed.service';
+import { SorobanAuthService } from './soroban-auth.service';
 
 @Module({
   controllers: [StellarController],
-  providers: [StellarService, PriceFeedService, XlmPriceService],
-  exports: [StellarService, PriceFeedService, XlmPriceService],
+  providers: [StellarService, PriceFeedService, XlmPriceService, SorobanAuthService],
+  exports: [StellarService, PriceFeedService, XlmPriceService, SorobanAuthService],
 })
 export class StellarModule {}


### PR DESCRIPTION
## Summary

- Added automatic authorization type detection for Soroban transactions.
- Added decoding for Smart Wallet Contract IDs.
- Preserved existing Ed25519 decoding behavior.
- Added unit tests and updated documentation.

## Changes

### `src/stellar/soroban-auth.service.ts`
New `SorobanAuthService` with `decodeAuthorizationEntry(base64XDR)` that inspects the XDR credential switch:
- `sorobanCredentialsSourceAccount` → **Ed25519**
- `sorobanCredentialsAddress` + `scAddressTypeAccount` → **Ed25519** with public key
- `sorobanCredentialsAddress` + `scAddressTypeContract` → **SmartWallet** with contract ID
- Malformed/empty payloads throw descriptive errors

### `src/stellar/soroban-auth.service.spec.ts`
18 unit tests using real XDR fixtures covering all credential paths, type detection correctness, and error handling.

### `src/stellar/stellar.module.ts`
`SorobanAuthService` added to providers and exports.

### `src/stellar/README.md`
Documentation with detection logic, API, and output examples for all authorization types.

Closes #271