### PR TITLE
feat: implement Circuit Breaker Interceptor 

### DIFF
--- a/src/common/filters/circuit-breaker.interceptor.spec.ts
+++ b/src/common/filters/circuit-breaker.interceptor.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * @jest-environment node
+ */
+
+import { ExecutionContext, CallHandler, ServiceUnavailableException } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { CircuitBreakerInterceptor, CircuitState } from './circuit-breaker.interceptor';
+
+const mockContext = {} as ExecutionContext;
+
+const successHandler: CallHandler = { handle: () => of({ ok: true }) };
+const failHandler: CallHandler = {
+  handle: () => throwError(() => new Error('upstream error')),
+};
+
+describe('CircuitBreakerInterceptor', () => {
+  const THRESHOLD = 3;
+  const RESET_TIMEOUT = 300;
+
+  let interceptor: CircuitBreakerInterceptor;
+
+  beforeEach(() => {
+    interceptor = new CircuitBreakerInterceptor({
+      failureThreshold: THRESHOLD,
+      resetTimeout: RESET_TIMEOUT,
+      serviceName: 'test-service',
+    });
+  });
+
+  // ── initial state ──────────────────────────────────────────────────────────
+
+  describe('initial state', () => {
+    it('starts in CLOSED state', () => {
+      expect(interceptor.getState()).toBe(CircuitState.CLOSED);
+    });
+
+    it('starts with zero failure count', () => {
+      expect(interceptor.getFailureCount()).toBe(0);
+    });
+  });
+
+  // ── CLOSED behaviour ───────────────────────────────────────────────────────
+
+  describe('CLOSED state', () => {
+    it('passes a successful request through', (done) => {
+      interceptor.intercept(mockContext, successHandler).subscribe({
+        next: (val) => expect(val).toEqual({ ok: true }),
+        complete: done,
+      });
+    });
+
+    it('re-throws upstream errors without opening below threshold', (done) => {
+      interceptor.intercept(mockContext, failHandler).subscribe({
+        error: (err) => {
+          expect(err.message).toBe('upstream error');
+          expect(interceptor.getState()).toBe(CircuitState.CLOSED);
+          done();
+        },
+      });
+    });
+
+    it('increments failure count on each error', (done) => {
+      interceptor.intercept(mockContext, failHandler).subscribe({
+        error: () => {
+          expect(interceptor.getFailureCount()).toBe(1);
+          done();
+        },
+      });
+    });
+  });
+
+  // ── threshold-triggered OPEN ───────────────────────────────────────────────
+
+  describe('opening the circuit on failure threshold', () => {
+    function triggerFailures(count: number, cb: () => void) {
+      let remaining = count;
+      for (let i = 0; i < count; i++) {
+        interceptor.intercept(mockContext, failHandler).subscribe({
+          error: () => {
+            remaining -= 1;
+            if (remaining === 0) cb();
+          },
+        });
+      }
+    }
+
+    it('transitions to OPEN after failureThreshold consecutive failures', (done) => {
+      triggerFailures(THRESHOLD, () => {
+        expect(interceptor.getState()).toBe(CircuitState.OPEN);
+        done();
+      });
+    });
+
+    it('fast-fails with ServiceUnavailableException while OPEN', (done) => {
+      triggerFailures(THRESHOLD, () => {
+        interceptor.intercept(mockContext, successHandler).subscribe({
+          error: (err) => {
+            expect(err).toBeInstanceOf(ServiceUnavailableException);
+            done();
+          },
+        });
+      });
+    });
+
+    it('does not call the upstream handler while OPEN', (done) => {
+      const spy = jest.fn().mockReturnValue(of({ ok: true }));
+      const spyHandler: CallHandler = { handle: spy };
+
+      triggerFailures(THRESHOLD, () => {
+        interceptor.intercept(mockContext, spyHandler).subscribe({
+          error: () => {
+            expect(spy).not.toHaveBeenCalled();
+            done();
+          },
+        });
+      });
+    });
+  });
+
+  // ── HALF_OPEN trial request ────────────────────────────────────────────────
+
+  describe('HALF_OPEN after reset timeout', () => {
+    function openThenWait(cb: () => void) {
+      let remaining = THRESHOLD;
+      for (let i = 0; i < THRESHOLD; i++) {
+        interceptor.intercept(mockContext, failHandler).subscribe({
+          error: () => {
+            remaining -= 1;
+            if (remaining === 0) {
+              setTimeout(cb, RESET_TIMEOUT + 50);
+            }
+          },
+        });
+      }
+    }
+
+    it('closes the circuit when the trial request succeeds', (done) => {
+      openThenWait(() => {
+        interceptor.intercept(mockContext, successHandler).subscribe({
+          complete: () => {
+            expect(interceptor.getState()).toBe(CircuitState.CLOSED);
+            expect(interceptor.getFailureCount()).toBe(0);
+            done();
+          },
+        });
+      });
+    });
+
+    it('re-opens the circuit when the trial request fails', (done) => {
+      openThenWait(() => {
+        interceptor.intercept(mockContext, failHandler).subscribe({
+          error: () => {
+            expect(interceptor.getState()).toBe(CircuitState.OPEN);
+            done();
+          },
+        });
+      });
+    });
+  });
+
+  // ── reset helper ───────────────────────────────────────────────────────────
+
+  describe('reset()', () => {
+    it('forces circuit back to CLOSED from OPEN', (done) => {
+      let remaining = THRESHOLD;
+      for (let i = 0; i < THRESHOLD; i++) {
+        interceptor.intercept(mockContext, failHandler).subscribe({
+          error: () => {
+            remaining -= 1;
+            if (remaining === 0) {
+              interceptor.reset();
+              expect(interceptor.getState()).toBe(CircuitState.CLOSED);
+              expect(interceptor.getFailureCount()).toBe(0);
+              done();
+            }
+          },
+        });
+      }
+    });
+
+    it('allows normal traffic after a reset', (done) => {
+      let remaining = THRESHOLD;
+      for (let i = 0; i < THRESHOLD; i++) {
+        interceptor.intercept(mockContext, failHandler).subscribe({
+          error: () => {
+            remaining -= 1;
+            if (remaining === 0) {
+              interceptor.reset();
+              interceptor.intercept(mockContext, successHandler).subscribe({
+                next: (val) => expect(val).toEqual({ ok: true }),
+                complete: done,
+              });
+            }
+          },
+        });
+      }
+    });
+  });
+});

--- a/src/common/filters/circuit-breaker.interceptor.ts
+++ b/src/common/filters/circuit-breaker.interceptor.ts
@@ -1,0 +1,132 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { Observable, throwError } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+
+export enum CircuitState {
+  CLOSED = 'CLOSED',
+  OPEN = 'OPEN',
+  HALF_OPEN = 'HALF_OPEN',
+}
+
+export interface CircuitBreakerOptions {
+  failureThreshold: number;
+  resetTimeout: number;
+  serviceName?: string;
+}
+
+const DEFAULT_OPTIONS: Required<CircuitBreakerOptions> = {
+  failureThreshold: 5,
+  resetTimeout: 30_000,
+  serviceName: 'external-service',
+};
+
+@Injectable()
+export class CircuitBreakerInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(CircuitBreakerInterceptor.name);
+
+  private state: CircuitState = CircuitState.CLOSED;
+  private failureCount = 0;
+  private openedAt: number | null = null;
+
+  private readonly options: Required<CircuitBreakerOptions>;
+
+  constructor(options: Partial<CircuitBreakerOptions> = {}) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (this.state === CircuitState.OPEN) {
+      const elapsed = Date.now() - (this.openedAt ?? 0);
+
+      if (elapsed >= this.options.resetTimeout) {
+        this.transitionTo(CircuitState.HALF_OPEN);
+        this.logger.log(
+          `[${this.options.serviceName}] Circuit transitioning to HALF_OPEN — allowing trial request`,
+        );
+      } else {
+        this.logger.warn(
+          `[${this.options.serviceName}] Circuit OPEN — fast-failing (${Math.round(this.options.resetTimeout - elapsed)}ms until half-open)`,
+        );
+        return throwError(
+          () =>
+            new ServiceUnavailableException(
+              `Service ${this.options.serviceName} is currently unavailable. Please try again later.`,
+            ),
+        );
+      }
+    }
+
+    return next.handle().pipe(
+      tap(() => this.onSuccess()),
+      catchError((err: unknown) => {
+        this.onFailure();
+        return throwError(() => err);
+      }),
+    );
+  }
+
+  private onSuccess(): void {
+    if (this.state === CircuitState.HALF_OPEN) {
+      this.logger.log(
+        `[${this.options.serviceName}] Trial request succeeded — closing circuit`,
+      );
+      this.transitionTo(CircuitState.CLOSED);
+    }
+    this.failureCount = 0;
+  }
+
+  private onFailure(): void {
+    this.failureCount += 1;
+
+    if (
+      this.state === CircuitState.HALF_OPEN ||
+      this.failureCount >= this.options.failureThreshold
+    ) {
+      this.logger.error(
+        `[${this.options.serviceName}] Failure threshold hit (${this.failureCount}/${this.options.failureThreshold}) — opening circuit`,
+      );
+      this.transitionTo(CircuitState.OPEN);
+    } else {
+      this.logger.warn(
+        `[${this.options.serviceName}] Failure recorded (${this.failureCount}/${this.options.failureThreshold})`,
+      );
+    }
+  }
+
+  private transitionTo(newState: CircuitState): void {
+    const prev = this.state;
+    this.state = newState;
+
+    if (newState === CircuitState.OPEN) {
+      this.openedAt = Date.now();
+    }
+
+    if (newState === CircuitState.CLOSED) {
+      this.failureCount = 0;
+      this.openedAt = null;
+    }
+
+    this.logger.log(
+      `[${this.options.serviceName}] State: ${prev} → ${newState}`,
+    );
+  }
+
+  getState(): CircuitState {
+    return this.state;
+  }
+
+  getFailureCount(): number {
+    return this.failureCount;
+  }
+
+  reset(): void {
+    this.transitionTo(CircuitState.CLOSED);
+  }
+}


### PR DESCRIPTION
Closes #864

Added a Circuit Breaker interceptor to make our external calls more resilient.

This prevents one flaky service (Stellar, SMS provider, price feed, etc.) from taking down request handling across the board by failing fast when things go wrong.

### What's included
- New `src/common/filters/circuit-breaker.interceptor.ts` with full CLOSED / OPEN / HALF_OPEN logic
- Configurable `failureThreshold`, `resetTimeout`, and `serviceName`
- Proper state transitions, fast-fail behavior, and trial request in HALF_OPEN
- Public methods for inspection and manual reset
- Full test coverage (12 tests) in `circuit-breaker.interceptor.spec.ts`

The tests run cleanly with `@jest-environment node` so they don't depend on the database setup.

Everything passes:
Test Suites: 1 passed, 1 total
Tests: 12 passed, 12 total
textThis matches the scope defined in the ticket — just the interceptor itself. Wiring it into the services will come in follow-up PRs.

Ready for review.