### PR TITLE
feat: implement admin impersonation service (Closes #862)

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -8,6 +8,7 @@ module.exports = {
     '<rootDir>/users/health-profile/health-profile.service.spec.ts',
     '<rootDir>/tasks/assignment/bulk-task-assignment.service.spec.ts',
     '<rootDir>/modules/admin/admin-tasks.controller.spec.ts',
+    '<rootDir>/modules/admin/services/admin-impersonation.service.spec.ts',
     '<rootDir>/shared/queue/queue.service.spec.ts',
     '<rootDir>/shared/notifications/services/email-template.service.spec.ts',
     '<rootDir>/notifications/services/notification.service.spec.ts',

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -14,6 +14,7 @@ import { QueueModule } from '@/queue/queue.module';
 import { QueueService } from '@/shared/queue/queue.service';
 import { AdminService } from './services/admin.service';
 import { AdminUsersService } from './services/admin-users.service';
+import { AdminImpersonationService } from './services/admin-impersonation.service';
 import { FailedRewardJobService } from './rewards/failed-reward-job.service';
 import { User } from '@/entities/user.entity';
 import { TaskCompletion } from '@/tasks/entities/task-completion.entity';
@@ -37,6 +38,7 @@ import { ReportsModule } from '@modules/reports/reports.module';
   providers: [
     AdminService,
     AdminUsersService,
+    AdminImpersonationService,
     TasksScheduler,
     RewardsScheduler,
     FailedRewardJobService,

--- a/src/modules/admin/services/admin-impersonation.service.spec.ts
+++ b/src/modules/admin/services/admin-impersonation.service.spec.ts
@@ -1,0 +1,274 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { AdminImpersonationService } from './admin-impersonation.service';
+import { User } from '@/entities/user.entity';
+import { Role } from '@modules/auth/enums/role.enum';
+import { CacheService } from '@/shared/cache/cache.service';
+import { AuditService } from '@/audit/audit.service';
+import { AuditAction, AuditResource } from '@/audit/entities/audit-log.entity';
+
+describe('AdminImpersonationService', () => {
+  let service: AdminImpersonationService;
+  let usersRepository: jest.Mocked<Repository<User>>;
+  let cacheService: jest.Mocked<CacheService>;
+  let auditService: jest.Mocked<AuditService>;
+  let cacheStore: Map<string, any>;
+
+  beforeEach(async () => {
+    cacheStore = new Map<string, any>();
+
+    const mockUsersRepository = {
+      findOne: jest.fn(),
+    };
+
+    const mockCacheService = {
+      set: jest.fn().mockImplementation((key, value) => {
+        cacheStore.set(key, value);
+        return Promise.resolve();
+      }),
+      get: jest.fn().mockImplementation((key) => {
+        return Promise.resolve(cacheStore.get(key) || null);
+      }),
+    };
+
+    const mockAuditService = {
+      logEvent: jest.fn().mockResolvedValue(null),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminImpersonationService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUsersRepository,
+        },
+        {
+          provide: CacheService,
+          useValue: mockCacheService,
+        },
+        {
+          provide: AuditService,
+          useValue: mockAuditService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AdminImpersonationService>(AdminImpersonationService);
+    usersRepository = module.get(getRepositoryToken(User));
+    cacheService = module.get(CacheService);
+    auditService = module.get(AuditService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('startSession', () => {
+    const adminId = 'admin-id-123';
+    const targetUserId = 'user-id-456';
+    const reason = 'Assisting with troubleshooting billing issue';
+    let expiry: Date;
+
+    beforeEach(() => {
+      expiry = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes in future
+    });
+
+    it('should successfully start an impersonation session for a non-admin user', async () => {
+      const targetUser = { id: targetUserId, role: Role.USER } as User;
+      usersRepository.findOne.mockResolvedValue(targetUser);
+
+      const result = await service.startSession(adminId, targetUserId, expiry, reason);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+      expect(result.adminId).toBe(adminId);
+      expect(result.targetUserId).toBe(targetUserId);
+      expect(result.reason).toBe(reason);
+      expect(result.isActive).toBe(true);
+      expect(result.expiry).toBe(expiry.toISOString());
+
+      // Check stored in cache
+      expect(cacheService.set).toHaveBeenCalledWith(
+        `impersonation:${result.id}`,
+        result,
+        expect.any(Object),
+      );
+
+      // Verify audit logging
+      expect(auditService.logEvent).toHaveBeenCalledWith({
+        userId: adminId,
+        action: AuditAction.CREATE,
+        resourceType: AuditResource.USER,
+        resourceId: targetUserId,
+        description: expect.stringContaining(reason),
+        metadata: {
+          sessionId: result.id,
+          adminId,
+          targetUserId,
+          reason,
+          expiry: expiry.toISOString(),
+        },
+      });
+    });
+
+    it('should throw NotFoundException if target user does not exist', async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.startSession(adminId, targetUserId, expiry, reason),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(cacheService.set).not.toHaveBeenCalled();
+      expect(auditService.logEvent).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when attempting to impersonate an admin', async () => {
+      const targetUser = { id: targetUserId, role: Role.ADMIN } as User;
+      usersRepository.findOne.mockResolvedValue(targetUser);
+
+      await expect(
+        service.startSession(adminId, targetUserId, expiry, reason),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(cacheService.set).not.toHaveBeenCalled();
+      expect(auditService.logEvent).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException if expiry is in the past or now', async () => {
+      const targetUser = { id: targetUserId, role: Role.USER } as User;
+      usersRepository.findOne.mockResolvedValue(targetUser);
+      const pastExpiry = new Date(Date.now() - 1000);
+
+      await expect(
+        service.startSession(adminId, targetUserId, pastExpiry, reason),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(cacheService.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('endSession', () => {
+    const sessionId = 'session-uuid-123';
+    const adminId = 'admin-id-123';
+    const targetUserId = 'user-id-456';
+    const reason = 'Finished debug';
+    let expiry: string;
+
+    beforeEach(() => {
+      expiry = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    });
+
+    it('should end the session early successfully and log to audit service', async () => {
+      const activeSession = {
+        id: sessionId,
+        adminId,
+        targetUserId,
+        expiry,
+        reason,
+        isActive: true,
+      };
+      cacheStore.set(`impersonation:${sessionId}`, activeSession);
+
+      const result = await service.endSession(sessionId);
+
+      expect(result.isActive).toBe(false);
+      expect(cacheStore.get(`impersonation:${sessionId}`).isActive).toBe(false);
+
+      expect(auditService.logEvent).toHaveBeenCalledWith({
+        userId: adminId,
+        action: AuditAction.UPDATE,
+        resourceType: AuditResource.USER,
+        resourceId: targetUserId,
+        description: expect.stringContaining('Ended impersonation session early'),
+        metadata: {
+          sessionId,
+          adminId,
+          targetUserId,
+          reason,
+        },
+      });
+    });
+
+    it('should throw BadRequestException if session is not found in cache', async () => {
+      await expect(service.endSession('non-existent')).rejects.toThrow(BadRequestException);
+      expect(auditService.logEvent).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException if session is already ended/inactive', async () => {
+      const inactiveSession = {
+        id: sessionId,
+        adminId,
+        targetUserId,
+        expiry,
+        reason,
+        isActive: false,
+      };
+      cacheStore.set(`impersonation:${sessionId}`, inactiveSession);
+
+      await expect(service.endSession(sessionId)).rejects.toThrow(BadRequestException);
+      expect(auditService.logEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isSessionValid', () => {
+    const sessionId = 'session-uuid-123';
+    const adminId = 'admin-id-123';
+    const targetUserId = 'user-id-456';
+    const reason = 'Debug';
+
+    it('should return true for active, non-expired sessions', async () => {
+      const expiry = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+      const session = {
+        id: sessionId,
+        adminId,
+        targetUserId,
+        expiry,
+        reason,
+        isActive: true,
+      };
+      cacheStore.set(`impersonation:${sessionId}`, session);
+
+      const isValid = await service.isSessionValid(sessionId);
+      expect(isValid).toBe(true);
+    });
+
+    it('should return false if session is inactive', async () => {
+      const expiry = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+      const session = {
+        id: sessionId,
+        adminId,
+        targetUserId,
+        expiry,
+        reason,
+        isActive: false,
+      };
+      cacheStore.set(`impersonation:${sessionId}`, session);
+
+      const isValid = await service.isSessionValid(sessionId);
+      expect(isValid).toBe(false);
+    });
+
+    it('should return false if session is expired', async () => {
+      const expiry = new Date(Date.now() - 1000).toISOString(); // 1s ago
+      const session = {
+        id: sessionId,
+        adminId,
+        targetUserId,
+        expiry,
+        reason,
+        isActive: true,
+      };
+      cacheStore.set(`impersonation:${sessionId}`, session);
+
+      const isValid = await service.isSessionValid(sessionId);
+      expect(isValid).toBe(false);
+    });
+
+    it('should return false if session is not found in cache', async () => {
+      const isValid = await service.isSessionValid('non-existent');
+      expect(isValid).toBe(false);
+    });
+  });
+});

--- a/src/modules/admin/services/admin-impersonation.service.ts
+++ b/src/modules/admin/services/admin-impersonation.service.ts
@@ -1,0 +1,142 @@
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { randomUUID } from 'crypto';
+import { User } from '@/entities/user.entity';
+import { Role } from '@modules/auth/enums/role.enum';
+import { CacheService } from '@/shared/cache/cache.service';
+import { AuditService } from '@/audit/audit.service';
+import { AuditAction, AuditResource } from '@/audit/entities/audit-log.entity';
+
+export interface ImpersonationSession {
+  id: string;
+  adminId: string;
+  targetUserId: string;
+  expiry: string; // ISO String
+  reason: string;
+  isActive: boolean;
+}
+
+@Injectable()
+export class AdminImpersonationService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+    private readonly cacheService: CacheService,
+    private readonly auditService: AuditService,
+  ) {}
+
+  /**
+   * Starts an impersonation session
+   */
+  async startSession(
+    adminId: string,
+    targetUserId: string,
+    expiry: Date,
+    reason: string,
+  ): Promise<ImpersonationSession> {
+    const targetUser = await this.usersRepository.findOne({
+      where: { id: targetUserId },
+    });
+
+    if (!targetUser) {
+      throw new NotFoundException('Target user not found');
+    }
+
+    if (targetUser.role === Role.ADMIN) {
+      throw new BadRequestException('Attempting to impersonate an admin user is rejected');
+    }
+
+    const now = new Date();
+    if (expiry.getTime() <= now.getTime()) {
+      throw new BadRequestException('Expiry time must be in the future');
+    }
+
+    const sessionId = randomUUID();
+    const session: ImpersonationSession = {
+      id: sessionId,
+      adminId,
+      targetUserId,
+      expiry: expiry.toISOString(),
+      reason,
+      isActive: true,
+    };
+
+    const ttl = Math.ceil((expiry.getTime() - now.getTime()) / 1000);
+    await this.cacheService.set(`impersonation:${sessionId}`, session, { ttl });
+
+    await this.auditService.logEvent({
+      userId: adminId,
+      action: AuditAction.CREATE,
+      resourceType: AuditResource.USER,
+      resourceId: targetUserId,
+      description: `Started impersonation session for user ${targetUserId}. Reason: ${reason}`,
+      metadata: {
+        sessionId,
+        adminId,
+        targetUserId,
+        reason,
+        expiry: expiry.toISOString(),
+      },
+    });
+
+    return session;
+  }
+
+  /**
+   * Ends an impersonation session early
+   */
+  async endSession(sessionId: string): Promise<ImpersonationSession> {
+    const session = await this.cacheService.get<ImpersonationSession>(
+      `impersonation:${sessionId}`,
+    );
+
+    if (!session || !session.isActive) {
+      throw new BadRequestException('Session not found or already inactive');
+    }
+
+    session.isActive = false;
+    // Overwrite the session in cache
+    await this.cacheService.set(`impersonation:${sessionId}`, session);
+
+    await this.auditService.logEvent({
+      userId: session.adminId,
+      action: AuditAction.UPDATE,
+      resourceType: AuditResource.USER,
+      resourceId: session.targetUserId,
+      description: `Ended impersonation session early for user ${session.targetUserId}`,
+      metadata: {
+        sessionId,
+        adminId: session.adminId,
+        targetUserId: session.targetUserId,
+        reason: session.reason,
+      },
+    });
+
+    return session;
+  }
+
+  /**
+   * Checks if an impersonation session is currently valid
+   */
+  async isSessionValid(sessionId: string): Promise<boolean> {
+    const session = await this.cacheService.get<ImpersonationSession>(
+      `impersonation:${sessionId}`,
+    );
+
+    if (!session) {
+      return false;
+    }
+
+    if (!session.isActive) {
+      return false;
+    }
+
+    const expiryDate = new Date(session.expiry);
+    if (expiryDate.getTime() <= Date.now()) {
+      return false;
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION

Closes #862
Summary of Changes
Introduced the AdminImpersonationService allowing administrators to start, end early, and check the validity of short-lived, fully audited impersonation sessions for support and troubleshooting purposes.

Key changes:

AdminImpersonationService: Added in src/modules/admin/services/admin-impersonation.service.ts exposing:
startSession(...): Validates that the target user is not an ADMIN, generates a session ID, stores the session metadata in the cache with the appropriate TTL, and logs the session creation to the Audit Log.
endSession(...): Validates and deactivates the session early, updates the cache, and logs the deactivation to the Audit Log.
isSessionValid(...): Resolves the session and ensures it is active and not yet expired.
Module Integration: Wired AdminImpersonationService as a provider inside src/modules/admin/admin.module.ts.
Isolated Unit Testing: Added 
admin-impersonation.service.spec.ts
 covering session validation, error boundaries (like trying to impersonate other admins or using expired timestamps), and audit logging. Registered the spec file in jest.unit.config.js.