### PR TITLE
TaskExportRequest

### DIFF
--- a/src/database/entities/README.md
+++ b/src/database/entities/README.md
@@ -5,17 +5,28 @@ This directory contains all TypeORM entities for the Stellar Uzima backend.
 ## Overview
 
 Entities represent database tables and define the schema structure. Each entity:
+
 - Maps to a database table
 - Defines column types and constraints
 - May include relationships to other entities
 - Should have proper documentation
+
+## Current Entities
+
+- `TaskExportRequest` maps to `task_export_requests` and tracks health-task export requests independently from account-level exports. It stores the requesting user, lifecycle status, requested timestamp, completion timestamp, download expiry, and audit timestamps.
 
 ## Creating an Entity
 
 ### Basic Entity Structure
 
 ```typescript
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Entity('users')
 export class User {
@@ -160,6 +171,7 @@ email: string;
 1. **Use UUID for Primary Keys**
    - More secure than auto-increment integers
    - Better for distributed systems
+
    ```typescript
    @PrimaryGeneratedColumn('uuid')
    id: string;
@@ -167,6 +179,7 @@ email: string;
 
 2. **Add Timestamps**
    - Track creation and modification dates
+
    ```typescript
    @CreateDateColumn()
    createdAt: Date;
@@ -177,6 +190,7 @@ email: string;
 
 3. **Add Soft Delete**
    - Keep historical data while marking as deleted
+
    ```typescript
    @DeleteDateColumn()
    deletedAt?: Date;
@@ -184,6 +198,7 @@ email: string;
 
 4. **Index Frequently Queried Columns**
    - Improves query performance
+
    ```typescript
    @Index()
    @Column()
@@ -192,6 +207,7 @@ email: string;
 
 5. **Use Nullable Wisely**
    - Mark truly optional fields as nullable
+
    ```typescript
    @Column({ nullable: true })
    middleName?: string;
@@ -200,7 +216,7 @@ email: string;
 6. **Add Comments**
    - Document complex fields
    ```typescript
-   @Column({ 
+   @Column({
      comment: 'User email address for login and notifications'
    })
    email: string;

--- a/src/database/entities/task-export-request.entity.spec.ts
+++ b/src/database/entities/task-export-request.entity.spec.ts
@@ -1,0 +1,83 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { getMetadataArgsStorage } from 'typeorm';
+import { TaskExportRequest, TaskExportRequestStatus } from './task-export-request.entity';
+
+describe('TaskExportRequest entity', () => {
+  const validUserId = '3d6f0a4e-d3ea-4bc1-ae7b-7db9f79ba12a';
+
+  it('maps to the task_export_requests table with required columns', () => {
+    const table = getMetadataArgsStorage().tables.find(
+      (metadata) => metadata.target === TaskExportRequest
+    );
+    const columns = getMetadataArgsStorage().columns.filter(
+      (metadata) => metadata.target === TaskExportRequest
+    );
+
+    expect(table?.name).toBe('task_export_requests');
+    expect(columns.map((column) => column.propertyName)).toEqual(
+      expect.arrayContaining([
+        'id',
+        'userId',
+        'status',
+        'requestedAt',
+        'completedAt',
+        'downloadExpiresAt',
+        'createdAt',
+        'updatedAt',
+      ])
+    );
+
+    expect(columns.find((column) => column.propertyName === 'userId')?.options).toMatchObject({
+      type: 'uuid',
+    });
+    expect(columns.find((column) => column.propertyName === 'requestedAt')?.options).toMatchObject({
+      type: 'timestamp',
+    });
+    expect(columns.find((column) => column.propertyName === 'completedAt')?.options).toMatchObject({
+      type: 'timestamp',
+      nullable: true,
+    });
+    expect(
+      columns.find((column) => column.propertyName === 'downloadExpiresAt')?.options
+    ).toMatchObject({
+      type: 'timestamp',
+      nullable: true,
+    });
+  });
+
+  it('defines only the supported export request statuses', () => {
+    expect(Object.values(TaskExportRequestStatus)).toEqual([
+      'pending',
+      'processing',
+      'completed',
+      'failed',
+      'expired',
+    ]);
+  });
+
+  it('accepts a valid request record', async () => {
+    const request = new TaskExportRequest();
+    request.userId = validUserId;
+    request.status = TaskExportRequestStatus.PENDING;
+    request.requestedAt = new Date();
+
+    await expect(validate(request)).resolves.toHaveLength(0);
+  });
+
+  it('requires a valid user id, status, and requested date', async () => {
+    const request = new TaskExportRequest();
+    request.userId = 'not-a-uuid';
+    request.status = 'queued' as TaskExportRequestStatus;
+    request.requestedAt = '2026-06-28' as unknown as Date;
+
+    const errors = await validate(request);
+    const constraintsByProperty = Object.fromEntries(
+      errors.map((error) => [error.property, Object.keys(error.constraints ?? {})])
+    );
+
+    expect(constraintsByProperty.userId).toContain('isUuid');
+    expect(constraintsByProperty.status).toContain('isEnum');
+    expect(constraintsByProperty.requestedAt).toContain('isDate');
+  });
+});

--- a/src/database/entities/task-export-request.entity.ts
+++ b/src/database/entities/task-export-request.entity.ts
@@ -1,0 +1,65 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { IsDate, IsEnum, IsOptional, IsUUID } from 'class-validator';
+import { User } from './user.entity';
+
+export enum TaskExportRequestStatus {
+  PENDING = 'pending',
+  PROCESSING = 'processing',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  EXPIRED = 'expired',
+}
+
+@Entity('task_export_requests')
+@Index(['userId', 'requestedAt'])
+@Index(['status'])
+@Index(['downloadExpiresAt'])
+export class TaskExportRequest {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  @IsUUID()
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({
+    type: 'enum',
+    enum: TaskExportRequestStatus,
+    default: TaskExportRequestStatus.PENDING,
+  })
+  @IsEnum(TaskExportRequestStatus)
+  status: TaskExportRequestStatus;
+
+  @Column({ type: 'timestamp' })
+  @IsDate()
+  requestedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  @IsOptional()
+  @IsDate()
+  completedAt?: Date | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  @IsOptional()
+  @IsDate()
+  downloadExpiresAt?: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/database/migrations/1782100000000-CreateTaskExportRequestsTable.ts
+++ b/src/database/migrations/1782100000000-CreateTaskExportRequestsTable.ts
@@ -1,0 +1,110 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+export class CreateTaskExportRequestsTable1782100000000 implements MigrationInterface {
+  name = 'CreateTaskExportRequestsTable1782100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "CREATE TYPE \"task_export_requests_status_enum\" AS ENUM('pending', 'processing', 'completed', 'failed', 'expired')"
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'task_export_requests',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'gen_random_uuid()',
+          },
+          {
+            name: 'userId',
+            type: 'uuid',
+          },
+          {
+            name: 'status',
+            type: 'task_export_requests_status_enum',
+            default: "'pending'",
+          },
+          {
+            name: 'requestedAt',
+            type: 'timestamp',
+          },
+          {
+            name: 'completedAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'downloadExpiresAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true
+    );
+
+    await queryRunner.createForeignKey(
+      'task_export_requests',
+      new TableForeignKey({
+        name: 'FK_task_export_requests_userId',
+        columnNames: ['userId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'CASCADE',
+      })
+    );
+
+    await queryRunner.createIndex(
+      'task_export_requests',
+      new TableIndex({
+        name: 'IDX_task_export_requests_userId_requestedAt',
+        columnNames: ['userId', 'requestedAt'],
+      })
+    );
+
+    await queryRunner.createIndex(
+      'task_export_requests',
+      new TableIndex({
+        name: 'IDX_task_export_requests_status',
+        columnNames: ['status'],
+      })
+    );
+
+    await queryRunner.createIndex(
+      'task_export_requests',
+      new TableIndex({
+        name: 'IDX_task_export_requests_downloadExpiresAt',
+        columnNames: ['downloadExpiresAt'],
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex(
+      'task_export_requests',
+      'IDX_task_export_requests_downloadExpiresAt'
+    );
+    await queryRunner.dropIndex('task_export_requests', 'IDX_task_export_requests_status');
+    await queryRunner.dropIndex(
+      'task_export_requests',
+      'IDX_task_export_requests_userId_requestedAt'
+    );
+    await queryRunner.dropForeignKey('task_export_requests', 'FK_task_export_requests_userId');
+    await queryRunner.dropTable('task_export_requests');
+    await queryRunner.query('DROP TYPE "task_export_requests_status_enum"');
+  }
+}


### PR DESCRIPTION
## Summary

Closes #861

Adds a dedicated `TaskExportRequest` database entity and migration to track health-task export requests separately from the existing account-level data export flow.

## Changes

- Added `TaskExportRequest` entity for `task_export_requests`
- Added `TaskExportRequestStatus` enum with:
  - `pending`
  - `processing`
  - `completed`
  - `failed`
  - `expired`
- Added migration to create:
  - `task_export_requests` table
  - status enum type
  - user foreign key
  - indexes for user/request date, status, and download expiry
- Added entity spec covering:
  - required fields
  - enum status values
  - TypeORM table/column metadata
- Documented the new entity in `src/database/entities/README.md`

## Testing

```bash
npm test -- task-export-request