### PR TITLE
feat(admin): add GET /admin/users/:id/streaks endpoint

### DIFF
--- a/src/modules/admin/admin-users.controller.ts
+++ b/src/modules/admin/admin-users.controller.ts
@@ -61,6 +61,15 @@ export class AdminUsersController {
     return this.adminUsersService.getUserById(id);
   }
 
+  @Get(':id/streaks')
+  @ApiOperation({ summary: 'Get user streak history' })
+  @ApiParam({ name: 'id', description: 'User ID', type: 'string' })
+  @ApiResponse({ status: 200, description: 'User streaks found' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async getStreaks(@Param('id') id: string) {
+    return this.adminUsersService.getUserStreaks(id);
+  }
+
   @Patch(':id/role')
   @ApiOperation({ summary: 'Change user role' })
   @ApiResponse({ status: 200, description: 'Role updated successfully' })

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -23,6 +23,8 @@ import { TasksScheduler } from '@/tasks/tasks.scheduler';
 import { RewardsScheduler } from '@/rewards/rewards.scheduler';
 import { ReportsModule } from '@modules/reports/reports.module';
 
+import { StreaksModule } from '@/streaks/streaks.module';
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, TaskCompletion, RewardTransaction]),
@@ -33,6 +35,7 @@ import { ReportsModule } from '@modules/reports/reports.module';
     AuthModule,
     ReportsModule,
     QueueModule,
+    StreaksModule,
   ],
   controllers: [AdminController, AdminUsersController, AdminTasksController, FailedRewardJobController],
   providers: [

--- a/src/modules/admin/services/admin-users.service.ts
+++ b/src/modules/admin/services/admin-users.service.ts
@@ -3,6 +3,7 @@ import {
   BadRequestException,
   ForbiddenException,
   ConflictException,
+  NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -14,6 +15,7 @@ import { CreateAdminDto } from '../dto/create-admin.dto';
 import { Role } from '@modules/auth/enums/role.enum';
 import { UserStatus } from '@modules/auth/enums/user-status.enum';
 import { AuditService } from '@/audit/audit.service';
+import { StreaksService } from '@/streaks/streaks.service';
 
 @Injectable()
 export class AdminUsersService {
@@ -23,6 +25,7 @@ export class AdminUsersService {
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
     private readonly auditService: AuditService,
+    private readonly streaksService: StreaksService,
   ) {
     this.redisClient = createClient({
       url: process.env.REDIS_URL || 'redis://localhost:6379',
@@ -134,6 +137,19 @@ export class AdminUsersService {
       throw new BadRequestException('User not found');
     }
     return user;
+  }
+
+  async getUserStreaks(id: string) {
+    // verify user exists, which returns 404 (or throws BadRequest/NotFound depending on service)
+    // Wait, the instructions say "Returns 404 if user not found".
+    // getUserById throws BadRequestException in AdminUsersService. 
+    // We can just use userRepo to check if user exists.
+    const user = await this.usersRepository.findOne({ where: { id } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    
+    return this.streaksService.getStreakHistory(id);
   }
 
   async changeRole(adminId: string, userId: string, role: Role) {


### PR DESCRIPTION
 This PR resolves #1026 by adding a protected admin endpoint to review a specific user's streak data.

Changes Included:

AdminUsersController: Added the GET /admin/users/:id/streaks endpoint, which is globally protected by JwtAuthGuard and RolesGuard(Role.ADMIN).
AdminUsersService: Added getUserStreaks(id) which validates the user's existence and returns a 404 Not Found if the user is missing, then calls the StreaksService to retrieve the user's history.
AdminModule: Imported StreaksModule to allow the admin users service to utilize the dedicated streaks logic securely.
Acceptance Criteria Verified:

 Returns streak data for specified user.
 Returns 404 if user not found.
 Returns 403 for non-admin users (handled automatically by @Roles(Role.ADMIN)).
 Linked issue correctly.
 closes #1026 