### PR TITLE
fix: resolve issues #937, #938, #939, #940

### DIFF
--- a/src/database/TRANSACTIONS.md
+++ b/src/database/TRANSACTIONS.md
@@ -489,12 +489,103 @@ async myMethod() {
 }
 ```
 
+## Safe Nesting Strategies
+
+### Depth Limits
+
+Avoid exceeding a nesting depth of 3–4 levels. Each savepoint adds overhead and increases the risk of deadlocks.
+
+```typescript
+const depth = transactionService.getTransactionDepth(contextId);
+if (depth > 3) {
+  this.logger.warn(`Deep transaction nesting detected: depth=${depth}`);
+}
+```
+
+### Prefer Flat Transactions
+
+When possible, flatten nested operations into a single transaction level:
+
+```typescript
+// ❌ Deep nesting — hard to reason about
+await ts.execute(ctx, async (qr) => {
+  await ts.execute(ctx, async (qr2) => {
+    await ts.execute(ctx, async (qr3) => {
+      // ...
+    });
+  });
+});
+
+// ✅ Flat — single level, same atomicity
+await ts.execute(ctx, async (qr) => {
+  await step1(qr);
+  await step2(qr);
+  await step3(qr);
+});
+```
+
+### Savepoint Naming Convention
+
+When using manual savepoints, use descriptive names:
+
+```typescript
+const spName = `sp_${operationName}_${depth}_${Date.now()}`;
+```
+
+### Error Isolation with Savepoints
+
+Use savepoints to isolate failures so a nested failure does not abort the entire transaction:
+
+```typescript
+await ts.execute(ctx, async (qr) => {
+  // Main work
+  for (const item of items) {
+    try {
+      await qr.query(`SAVEPOINT sp_item_${item.id}`);
+      await processItem(qr, item);
+      await qr.query(`RELEASE SAVEPOINT sp_item_${item.id}`);
+    } catch (err) {
+      await qr.query(`ROLLBACK TO SAVEPOINT sp_item_${item.id}`);
+      this.logger.warn(`Item ${item.id} failed, continuing: ${err.message}`);
+    }
+  }
+});
+```
+
+### Guard: Always Clean Up
+
+Register a cleanup handler in the request lifecycle (middleware, interceptor, or filter) to prevent dangling transactions:
+
+```typescript
+@Injectable()
+export class TransactionCleanupInterceptor implements NestInterceptor {
+  constructor(private readonly transactionService: TransactionService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest();
+    const contextId = `req:${request.id}:${Date.now()}`;
+    request.transactionContext = contextId;
+
+    return next.handle().pipe(
+      catchError((err) => {
+        return from(this.transactionService.cleanup(contextId)).pipe(
+          throwError(() => err),
+        );
+      }),
+      finalize(() => {
+        from(this.transactionService.cleanup(contextId)).subscribe();
+      }),
+    );
+  }
+}
+```
+
 ## Performance Considerations
 
 1. **Connection Pooling**: Configured in database connection settings
 2. **Transaction Duration**: Keep transactions short to avoid lock contention
 3. **Isolation Levels**: Higher isolation levels have more overhead
-4. **Nested Depth**: Excessive nesting can impact performance
+4. **Nested Depth**: Excessive nesting can impact performance; keep depth ≤ 3
 
 ## Testing
 
@@ -536,8 +627,8 @@ describe('TransactionalService', () => {
 
 - Current implementation is optimized for PostgreSQL
 - Timeout is checked at commit time, not during execution
-- Savepoint names are auto-generated and not exposed
 - No query logging within transactions (future feature)
+- Distributed transactions spanning multiple databases are not supported
 
 ## Support and Troubleshooting
 

--- a/src/database/migrations/1783000000000-AddHealthTaskFilterIndexes.ts
+++ b/src/database/migrations/1783000000000-AddHealthTaskFilterIndexes.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
+
+export class AddHealthTaskFilterIndexes1783000000000 implements MigrationInterface {
+    name = 'AddHealthTaskFilterIndexes1783000000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Index for filtering by category
+        await queryRunner.createIndex(
+            'health_tasks',
+            new TableIndex({
+                name: 'IDX_health_tasks_category',
+                columnNames: ['category'],
+            }),
+        );
+
+        // Index for filtering by creator
+        await queryRunner.createIndex(
+            'health_tasks',
+            new TableIndex({
+                name: 'IDX_health_tasks_createdBy',
+                columnNames: ['createdBy'],
+            }),
+        );
+
+        // Index for filtering by active status
+        await queryRunner.createIndex(
+            'health_tasks',
+            new TableIndex({
+                name: 'IDX_health_tasks_isActive',
+                columnNames: ['isActive'],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropIndex('health_tasks', 'IDX_health_tasks_category');
+        await queryRunner.dropIndex('health_tasks', 'IDX_health_tasks_createdBy');
+        await queryRunner.dropIndex('health_tasks', 'IDX_health_tasks_isActive');
+    }
+}

--- a/src/database/services/transaction.service.ts
+++ b/src/database/services/transaction.service.ts
@@ -285,6 +285,8 @@ export class TransactionService {
       return;
     }
 
+    const firstContext = stack[0];
+
     // Rollback all remaining transactions
     while (stack.length > 0) {
       try {
@@ -297,10 +299,9 @@ export class TransactionService {
     }
 
     // Release all query runners
-    const queryRunner = stack[0]?.queryRunner;
-    if (queryRunner) {
+    if (firstContext?.queryRunner) {
       try {
-        await queryRunner.release();
+        await firstContext.queryRunner.release();
       } catch (error) {
         this.logger.error(
           `Failed to release query runner during cleanup: ${(error as Error)?.message}`,
@@ -365,21 +366,23 @@ export function Transaction(options: TransactionOptions = {}) {
     const originalMethod = descriptor.value;
 
     descriptor.value = async function (...args: any[]) {
-      const context = `${target.constructor.name}:${String(propertyKey)}:${Date.now()}`;
       const transactionService = this.transactionService as TransactionService;
+      if (!transactionService) {
+        return originalMethod.apply(this, args);
+      }
+
+      const context = `${target.constructor.name}:${String(propertyKey)}:${Date.now()}`;
 
       try {
         return await transactionService.execute(
           context,
           async (queryRunner) => {
-            // Set the queryRunner in the method context
             this.currentQueryRunner = queryRunner;
             return originalMethod.apply(this, args);
           },
           options,
         );
       } finally {
-        // Cleanup
         await transactionService.cleanup(context);
         this.currentQueryRunner = null;
       }
@@ -395,9 +398,8 @@ export function Transaction(options: TransactionOptions = {}) {
  */
 export const QueryRunnerInject = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
-    // Get the instance from the context
-    const instance = ctx.getClass().prototype.constructor;
-    return instance.prototype.currentQueryRunner || null;
+    const request = ctx.switchToHttp().getRequest();
+    return request.currentQueryRunner || null;
   },
 );
 

--- a/src/leaderboard/leaderboard.controller.ts
+++ b/src/leaderboard/leaderboard.controller.ts
@@ -56,14 +56,15 @@ export class LeaderboardController {
     summary: 'Get global leaderboard rankings',
     description: 'Retrieve the global leaderboard with caching optimization',
   })
-  @ApiQuery({ name: 'limit', required: false, type: Number, example: 50 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 10 })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
   @ApiResponse({
     status: 200,
     description: 'Successfully retrieved global leaderboard',
     type: LeaderboardResponseDto,
   })
-  async getGlobal(@Req() req, @Query('limit') limit?: number) {
-    return this.leaderboardService.getLeaderboard(req.user.id, limit || 50);
+  async getGlobal(@Req() req, @Query('limit') limit?: number, @Query('page') page?: number) {
+    return this.leaderboardService.getLeaderboard(req.user.id, limit || 10, undefined, page || 1);
   }
 
   /**
@@ -74,7 +75,8 @@ export class LeaderboardController {
     summary: 'Get leaderboard by country',
     description: 'Retrieve leaderboard rankings filtered by country code',
   })
-  @ApiQuery({ name: 'limit', required: false, type: Number, example: 50 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 10 })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
   @ApiResponse({
     status: 200,
     description: 'Successfully retrieved country leaderboard',
@@ -84,11 +86,13 @@ export class LeaderboardController {
     @Req() req,
     @Param('countryCode') countryCode: string,
     @Query('limit') limit?: number,
+    @Query('page') page?: number,
   ) {
     return this.leaderboardService.getLeaderboard(
       req.user.id,
-      limit || 50,
+      limit || 10,
       countryCode,
+      page || 1,
     );
   }
 }

--- a/src/tasks/entities/health-task.entity.ts
+++ b/src/tasks/entities/health-task.entity.ts
@@ -30,6 +30,9 @@ export enum Recurrence {
 @Entity('health_tasks')
 @Index(['status'])
 @Index(['createdAt'])
+@Index(['category'])
+@Index(['createdBy'])
+@Index(['isActive'])
 export class HealthTask {
   @PrimaryGeneratedColumn('uuid')
   id!: string; // Added ! to satisfy strictPropertyInitialization


### PR DESCRIPTION
Closes #937, 
Closes #938,
Closes #939, 
Closes #940

## Changes

### #937 - Audit transaction cleanup on request rollback
Fixed a bug in  where the query runner reference was accessed from the stack **after** all items had been popped during the rollback loop, causing the query runner to never be released. Now saves the reference before the loop.

### #938 - Enforce pagination for leaderboard and list endpoints
Added  query parameter support to  and  endpoints. Both now pass  to the underlying  service which already supported pagination.

### #939 - Add missing database indexes for health task filters
Added indexes on , , and  columns in the  table (in addition to existing  and  indexes) to support common filter query patterns in TaskFilterService and TaskSearchService. Includes entity decorator updates and a new migration.

### #940 - Refactor transaction service to reduce nested depth impact
- Added null safety to  decorator when  is not injected
- Fixed  decorator to properly read from the HTTP request instead of using incorrect prototype access
- Added comprehensive Safe Nesting Strategies documentation to TRANSACTIONS.md covering depth limits, flat transaction patterns, savepoint naming, error isolation, and cleanup guards