### PR TITLE
feat(badges): add GET /users/me/badges/count endpoint

### DIFF
--- a/src/rewards/badges/badge.controller.ts
+++ b/src/rewards/badges/badge.controller.ts
@@ -3,9 +3,11 @@ import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@ne
 import { JwtAuthGuard } from '@modules/auth/guards/jwt-auth.guard';
 import { BadgeService } from './badge.service';
 import { BadgeListResponseDto, UserBadgesResponseDto } from './dto/badge.dto';
+import { Badge } from '../../database/entities/badge.entity';
+import { UserBadge } from '../../database/entities/user-badge.entity';
 
 @ApiTags('badges')
-@Controller('badges')
+@Controller(['badges', 'users/me/badges'])
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
 export class BadgeController {
@@ -23,8 +25,28 @@ export class BadgeController {
     type: BadgeListResponseDto,
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async getAllBadges(): Promise<BadgeListResponseDto> {
+  async getAllBadges(): Promise<Badge[]> {
     return this.badgeService.getAllBadges();
+  }
+
+  @Get('count')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Get current user's earned badge count",
+    description:
+      'Returns the total number of badges earned by the authenticated user using a COUNT query.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Badge count retrieved successfully',
+    schema: { example: { count: 3 } },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getCurrentUserBadgeCount(
+    @Request() req: { user: { sub?: string; id?: string; userId?: string } },
+  ): Promise<{ count: number }> {
+    const userId = req.user.sub ?? req.user.id ?? req.user.userId;
+    return this.badgeService.getUserBadgeCount(userId);
   }
 
   @Get('user/:userId')
@@ -45,7 +67,7 @@ export class BadgeController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'User not found' })
-  async getUserBadges(@Param('userId') userId: string): Promise<UserBadgesResponseDto> {
+  async getUserBadges(@Param('userId') userId: string): Promise<UserBadge[]> {
     return this.badgeService.getUserBadges(userId);
   }
 
@@ -62,9 +84,9 @@ export class BadgeController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getCurrentUserBadges(
-    @Request() req: { user: { sub: string; id?: string } }
-  ): Promise<UserBadgesResponseDto> {
-    const userId = req.user.sub ?? req.user.id;
+    @Request() req: { user: { sub?: string; id?: string; userId?: string } },
+  ): Promise<UserBadge[]> {
+    const userId = req.user.sub ?? req.user.id ?? req.user.userId;
     return this.badgeService.getUserBadges(userId);
   }
 }

--- a/src/rewards/badges/badge.service.spec.ts
+++ b/src/rewards/badges/badge.service.spec.ts
@@ -1,115 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing';
- feat/all-issues-anna
-import { BadgeService } from './badge.service';
-import { BadgeType } from './badge-type.enum';
-
-describe('BadgeService', () => {
-  let service: BadgeService;
-
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [BadgeService],
-    }).compile();
-
-    service = module.get<BadgeService>(BadgeService);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
-
-  describe('awardBadge', () => {
-    it('should award a badge to a user successfully', () => {
-      const result = service.awardBadge('user-1', BadgeType.STREAK_7);
-      expect(result).toBe(true);
-      expect(service.hasBadge('user-1', BadgeType.STREAK_7)).toBe(true);
-    });
-
-    it('should return false when awarding the same badge twice (no duplicate)', () => {
-      // First award
-      const firstResult = service.awardBadge('user-1', BadgeType.STREAK_7);
-      expect(firstResult).toBe(true);
-
-      // Second award - must NOT duplicate
-      const secondResult = service.awardBadge('user-1', BadgeType.STREAK_7);
-      expect(secondResult).toBe(false);
-
-      // User should still have only one entry for this badge
-      const badges = service.getUserBadges('user-1');
-      expect(badges.filter((b) => b === BadgeType.STREAK_7)).toHaveLength(1);
-    });
-
-    it('should throw an error for an invalid badge type', () => {
-      expect(() => {
-        service.awardBadge('user-1', 'INVALID_BADGE' as BadgeType);
-      }).toThrow('Invalid badge type: INVALID_BADGE');
-    });
-
-    it('should award different badge types to the same user', () => {
-      service.awardBadge('user-1', BadgeType.STREAK_7);
-      service.awardBadge('user-1', BadgeType.STREAK_30);
-      service.awardBadge('user-1', BadgeType.MILESTONE_10);
-
-      const badges = service.getUserBadges('user-1');
-      expect(badges).toHaveLength(3);
-      expect(badges).toContain(BadgeType.STREAK_7);
-      expect(badges).toContain(BadgeType.STREAK_30);
-      expect(badges).toContain(BadgeType.MILESTONE_10);
-    });
-
-    it('should handle multiple users independently', () => {
-      service.awardBadge('user-1', BadgeType.STREAK_7);
-      service.awardBadge('user-2', BadgeType.STREAK_7);
-
-      expect(service.getUserBadges('user-1')).toHaveLength(1);
-      expect(service.getUserBadges('user-2')).toHaveLength(1);
-    });
-  });
-
-  describe('hasBadge', () => {
-    it('should return false for user with no badges', () => {
-      expect(service.hasBadge('user-1', BadgeType.STREAK_7)).toBe(false);
-    });
-
-    it('should return true for user who has the badge', () => {
-      service.awardBadge('user-1', BadgeType.STREAK_7);
-      expect(service.hasBadge('user-1', BadgeType.STREAK_7)).toBe(true);
-    });
-
-    it('should return false for user who does not have the specific badge', () => {
-      service.awardBadge('user-1', BadgeType.STREAK_7);
-      expect(service.hasBadge('user-1', BadgeType.STREAK_30)).toBe(false);
-    });
-  });
-
-  describe('getUserBadges', () => {
-    it('should return empty array for user with no badges', () => {
-      expect(service.getUserBadges('user-1')).toEqual([]);
-    });
-
-    it('should return all badges for a user', () => {
-      service.awardBadge('user-1', BadgeType.STREAK_7);
-      service.awardBadge('user-1', BadgeType.MILESTONE_10);
-
-      const badges = service.getUserBadges('user-1');
-      expect(badges).toHaveLength(2);
-      expect(badges).toContain(BadgeType.STREAK_7);
-      expect(badges).toContain(BadgeType.MILESTONE_10);
-    });
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { BadgeService } from './badge.service';
 import { Badge, BadgeType } from '../../database/entities/badge.entity';
 import { UserBadge } from '../../database/entities/user-badge.entity';
 
-const mockBadgeRepo = { findOne: jest.fn(), find: jest.fn(), save: jest.fn(), create: jest.fn((d) => d) };
-const mockUserBadgeRepo = { findOne: jest.fn(), find: jest.fn(), save: jest.fn(), create: jest.fn((d) => d) };
+const mockBadgeRepo = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  save: jest.fn(),
+  create: jest.fn((d) => d),
+  count: jest.fn(),
+};
+const mockUserBadgeRepo = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  save: jest.fn(),
+  create: jest.fn((d) => d),
+  count: jest.fn(),
+};
 
 describe('BadgeService', () => {
   let service: BadgeService;
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -122,20 +34,63 @@ describe('BadgeService', () => {
     jest.clearAllMocks();
   });
 
-  it('should be defined', () => { expect(service).toBeDefined(); });
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
   it('getAllBadges returns all badges', async () => {
     mockBadgeRepo.find.mockResolvedValue([{ id: '1' }]);
     expect(await service.getAllBadges()).toHaveLength(1);
   });
+
   it('awardBadge returns null if badge not found', async () => {
     mockBadgeRepo.findOne.mockResolvedValue(null);
     expect(await service.awardBadge('u1', BadgeType.FIRST_TASK)).toBeNull();
   });
+
   it('awardBadge skips duplicate', async () => {
     mockBadgeRepo.findOne.mockResolvedValue({ id: 'b1' });
     mockUserBadgeRepo.findOne.mockResolvedValue({ id: 'ub1' });
     await service.awardBadge('u1', BadgeType.FIRST_TASK);
     expect(mockUserBadgeRepo.save).not.toHaveBeenCalled();
- main
+  });
+
+  describe('getUserBadgeCount', () => {
+    it('returns badge count using a COUNT query', async () => {
+      mockUserBadgeRepo.count.mockResolvedValue(3);
+
+      const result = await service.getUserBadgeCount('user-1');
+
+      expect(result).toEqual({ count: 3 });
+      expect(mockUserBadgeRepo.count).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+      });
+      expect(mockUserBadgeRepo.find).not.toHaveBeenCalled();
+    });
+
+    it('returns zero when the user has no badges', async () => {
+      mockUserBadgeRepo.count.mockResolvedValue(0);
+
+      await expect(service.getUserBadgeCount('user-2')).resolves.toEqual({ count: 0 });
+    });
+  });
+
+  describe('initializeBadges', () => {
+    it('skips seeding when badges already exist', async () => {
+      mockBadgeRepo.count.mockResolvedValue(2);
+
+      await service.initializeBadges();
+
+      expect(mockBadgeRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('seeds default badges when none exist', async () => {
+      mockBadgeRepo.count.mockResolvedValue(0);
+      mockBadgeRepo.save.mockResolvedValue({});
+
+      await service.initializeBadges();
+
+      expect(mockBadgeRepo.save).toHaveBeenCalled();
+    });
   });
 });

--- a/src/rewards/badges/badge.service.ts
+++ b/src/rewards/badges/badge.service.ts
@@ -1,108 +1,130 @@
- feat/all-issues-anna
 import { Injectable, Logger } from '@nestjs/common';
-import { BadgeType } from './badge-type.enum';
-
-export interface UserBadge {
-  userId: string;
-  badgeType: BadgeType;
-  awardedAt: Date;
-}
-
-@Injectable()
-export class BadgeService {
-  private readonly logger = new Logger(BadgeService.name);
-  private readonly userBadges = new Map<string, Set<BadgeType>>();
-
-  /**
-   * Award a badge to a user.
-   * Returns true if the badge was newly awarded, false if already owned.
-   * Throws an error for invalid badge types.
-   */
-  awardBadge(userId: string, badgeType: BadgeType): boolean {
-    // Validate badge type
-    const validBadgeTypes = Object.values(BadgeType);
-    if (!validBadgeTypes.includes(badgeType)) {
-      throw new Error(`Invalid badge type: ${badgeType}`);
-    }
-
-    // Initialize user badge set if not exists
-    if (!this.userBadges.has(userId)) {
-      this.userBadges.set(userId, new Set());
-    }
-
-    const userBadges = this.userBadges.get(userId)!;
-
-    // Check for duplicate
-    if (userBadges.has(badgeType)) {
-      this.logger.warn(
-        `User ${userId} already has badge ${badgeType} - skipping duplicate award`,
-      );
-      return false;
-    }
-
-    // Award the badge
-    userBadges.add(badgeType);
-    this.logger.log(`Awarded badge ${badgeType} to user ${userId}`);
-    return true;
-  }
-
-  /**
-   * Get all badges for a user.
-   */
-  getUserBadges(userId: string): BadgeType[] {
-    const badges = this.userBadges.get(userId);
-    return badges ? Array.from(badges) : [];
-  }
-
-  /**
-   * Check if a user has a specific badge.
-   */
-  hasBadge(userId: string, badgeType: BadgeType): boolean {
-    const badges = this.userBadges.get(userId);
-    return badges ? badges.has(badgeType) : false;
-import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Badge, BadgeType } from '../../database/entities/badge.entity';
 import { UserBadge } from '../../database/entities/user-badge.entity';
 
 const BADGE_DEFINITIONS = [
-  { type: BadgeType.FIRST_TASK, name: 'First Step', description: 'Completed your first health task', iconUrl: '/badges/first-task.svg' },
-  { type: BadgeType.STREAK_7, name: '7-Day Streak', description: 'Maintained a 7-day task streak', iconUrl: '/badges/streak-7.svg' },
-  { type: BadgeType.STREAK_30, name: '30-Day Streak', description: 'Maintained a 30-day task streak', iconUrl: '/badges/streak-30.svg' },
-  { type: BadgeType.TASKS_10, name: 'Dedicated', description: 'Completed 10 health tasks', iconUrl: '/badges/tasks-10.svg' },
-  { type: BadgeType.TASKS_50, name: 'Committed', description: 'Completed 50 health tasks', iconUrl: '/badges/tasks-50.svg' },
-  { type: BadgeType.TASKS_100, name: 'Champion', description: 'Completed 100 health tasks', iconUrl: '/badges/tasks-100.svg' },
+  {
+    type: BadgeType.FIRST_TASK,
+    name: 'First Step',
+    description: 'Completed your first health task',
+    iconUrl: '/badges/first-task.svg',
+  },
+  {
+    type: BadgeType.STREAK_7,
+    name: '7-Day Streak',
+    description: 'Maintained a 7-day task streak',
+    iconUrl: '/badges/streak-7.svg',
+  },
+  {
+    type: BadgeType.STREAK_30,
+    name: '30-Day Streak',
+    description: 'Maintained a 30-day task streak',
+    iconUrl: '/badges/streak-30.svg',
+  },
+  {
+    type: BadgeType.TASKS_10,
+    name: 'Dedicated',
+    description: 'Completed 10 health tasks',
+    iconUrl: '/badges/tasks-10.svg',
+  },
+  {
+    type: BadgeType.TASKS_50,
+    name: 'Committed',
+    description: 'Completed 50 health tasks',
+    iconUrl: '/badges/tasks-50.svg',
+  },
+  {
+    type: BadgeType.TASKS_100,
+    name: 'Champion',
+    description: 'Completed 100 health tasks',
+    iconUrl: '/badges/tasks-100.svg',
+  },
 ];
 
 @Injectable()
 export class BadgeService {
+  private readonly logger = new Logger(BadgeService.name);
+
   constructor(
     @InjectRepository(Badge) private readonly badgeRepository: Repository<Badge>,
     @InjectRepository(UserBadge) private readonly userBadgeRepository: Repository<UserBadge>,
   ) {}
 
-  async getAllBadges(): Promise<Badge[]> { return this.badgeRepository.find(); }
+  /**
+   * Seed default badge definitions when none exist yet.
+   */
+  async initializeBadges(): Promise<void> {
+    const badgeCount = await this.badgeRepository.count();
+    if (badgeCount > 0) {
+      return;
+    }
+
+    for (const definition of BADGE_DEFINITIONS) {
+      await this.badgeRepository.save(this.badgeRepository.create(definition));
+    }
+
+    this.logger.log('Default badges initialized successfully');
+  }
+
+  async getAllBadges(): Promise<Badge[]> {
+    return this.badgeRepository.find();
+  }
 
   async getUserBadges(userId: string): Promise<UserBadge[]> {
     return this.userBadgeRepository.find({ where: { userId } });
   }
 
-  async awardBadge(userId: string, badgeType: BadgeType): Promise<UserBadge | null> {
-    const badge = await this.badgeRepository.findOne({ where: { type: badgeType } });
-    if (!badge) return null;
-    const existing = await this.userBadgeRepository.findOne({ where: { userId, badgeId: badge.id } });
-    if (existing) return existing;
-    return this.userBadgeRepository.save(this.userBadgeRepository.create({ userId, badgeId: badge.id }));
+  /**
+   * Return the total number of badges earned by a user via a COUNT query
+   * (does not load badge rows into memory).
+   */
+  async getUserBadgeCount(userId: string): Promise<{ count: number }> {
+    const count = await this.userBadgeRepository.count({ where: { userId } });
+    return { count };
   }
 
-  async checkAndAwardMilestones(userId: string, completedTaskCount: number, currentStreak: number): Promise<void> {
-    if (completedTaskCount === 1) await this.awardBadge(userId, BadgeType.FIRST_TASK);
-    if (completedTaskCount >= 10) await this.awardBadge(userId, BadgeType.TASKS_10);
-    if (completedTaskCount >= 50) await this.awardBadge(userId, BadgeType.TASKS_50);
-    if (completedTaskCount >= 100) await this.awardBadge(userId, BadgeType.TASKS_100);
-    if (currentStreak >= 7) await this.awardBadge(userId, BadgeType.STREAK_7);
-    if (currentStreak >= 30) await this.awardBadge(userId, BadgeType.STREAK_30);
- main
+  async awardBadge(userId: string, badgeType: BadgeType): Promise<UserBadge | null> {
+    const badge = await this.badgeRepository.findOne({ where: { type: badgeType } });
+    if (!badge) {
+      return null;
+    }
+
+    const existing = await this.userBadgeRepository.findOne({
+      where: { userId, badgeId: badge.id },
+    });
+    if (existing) {
+      return existing;
+    }
+
+    return this.userBadgeRepository.save(
+      this.userBadgeRepository.create({ userId, badgeId: badge.id }),
+    );
+  }
+
+  async checkAndAwardMilestones(
+    userId: string,
+    completedTaskCount: number,
+    currentStreak: number,
+  ): Promise<void> {
+    if (completedTaskCount === 1) {
+      await this.awardBadge(userId, BadgeType.FIRST_TASK);
+    }
+    if (completedTaskCount >= 10) {
+      await this.awardBadge(userId, BadgeType.TASKS_10);
+    }
+    if (completedTaskCount >= 50) {
+      await this.awardBadge(userId, BadgeType.TASKS_50);
+    }
+    if (completedTaskCount >= 100) {
+      await this.awardBadge(userId, BadgeType.TASKS_100);
+    }
+    if (currentStreak >= 7) {
+      await this.awardBadge(userId, BadgeType.STREAK_7);
+    }
+    if (currentStreak >= 30) {
+      await this.awardBadge(userId, BadgeType.STREAK_30);
+    }
   }
 }


### PR DESCRIPTION
## Overview

This PR adds a **GET `/users/me/badges/count`** endpoint that returns the total number of badges earned by the authenticated user via a TypeORM `COUNT` query — so clients no longer need to fetch all badge records and count them locally.

Also resolves corrupted merge artifacts that were already present on `main` in `badge.service.ts` / `badge.service.spec.ts`, restoring a working TypeORM-backed `BadgeService` (including `initializeBadges`) required by `BadgeModule`.

## Related Issue

Closes #1066

## Changes

### 🏅 Badge Count Endpoint

* **[MODIFY]** `src/rewards/badges/badge.controller.ts`
  * Dual route prefixes: `badges` and `users/me/badges` (same pattern as streaks).
  * Adds authenticated `GET .../count` returning `{ count: number }`.
  * Guarded by `JwtAuthGuard` (401 for unauthenticated requests).

* **[MODIFY]** `src/rewards/badges/badge.service.ts`
  * Adds `getUserBadgeCount(userId)` using `userBadgeRepository.count(...)` (no full row load).
  * Restores clean TypeORM service + `initializeBadges()` after upstream merge corruption.

* **[MODIFY]** `src/rewards/badges/badge.service.spec.ts`
  * Coverage for COUNT-based `getUserBadgeCount`, including zero-count case.
  * Coverage for `initializeBadges` seed/skip behavior.

## Verification Results

```
npx jest --config jest.config.js badge
✅ 8/8 passed

BadgeService
  ✓ should be defined
  ✓ getAllBadges returns all badges
  ✓ awardBadge returns null if badge not found
  ✓ awardBadge skips duplicate
  getUserBadgeCount
    ✓ returns badge count using a COUNT query
    ✓ returns zero when the user has no badges
  initializeBadges
    ✓ skips seeding when badges already exist
    ✓ seeds default badges when none exist
```

| Acceptance Criteria | Status |
| --- | --- |
| Returns `{ count: number }` | ✅ `getUserBadgeCount` + controller `GET count` |
| Uses COUNT query (not loading all records) | ✅ `userBadgeRepository.count({ where: { userId } })` |
| Returns 401 for unauthenticated request | ✅ Controller-level `JwtAuthGuard` + `@ApiBearerAuth` |
| `npm run test -- badge` passes | ✅ 8/8 passed |

## Timeline

- MiaShayla committed


Made with [Cursor](https://cursor.com)