### PR TITLE
test(scheduler): add unit tests for cleanup scheduler (#1048)

### DIFF
--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { FindOperator, Repository } from 'typeorm';
 import { UsersService } from './users.service';
 import { User } from '../../entities/user.entity';
 import { UserStatusLog } from '../../entities/user-status-log.entity';
@@ -11,6 +11,7 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 describe('UsersService', () => {
   let service: UsersService;
   let userRepository: jest.Mocked<Repository<User>>;
+  let userStatusLogRepository: jest.Mocked<Repository<UserStatusLog>>;
 
   const mockUser = {
     id: 'user-id',
@@ -32,11 +33,13 @@ describe('UsersService', () => {
 
     const mockUserStatusLogRepository = {
       save: jest.fn(),
+      delete: jest.fn(),
     };
 
     const mockCacheManager = {
       get: jest.fn(),
       set: jest.fn(),
+      del: jest.fn(),
     };
 
     const mockPreferencesService = {
@@ -68,6 +71,7 @@ describe('UsersService', () => {
 
     service = module.get<UsersService>(UsersService);
     userRepository = module.get(getRepositoryToken(User));
+    userStatusLogRepository = module.get(getRepositoryToken(UserStatusLog));
   });
 
   it('should be defined', () => {
@@ -76,9 +80,7 @@ describe('UsersService', () => {
 
   describe('registerDeviceToken', () => {
     it('should throw BadRequestException if token is empty', async () => {
-      await expect(service.registerDeviceToken('user-id', '')).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(service.registerDeviceToken('user-id', '')).rejects.toThrow(BadRequestException);
     });
 
     it('should register a device token successfully', async () => {
@@ -91,7 +93,7 @@ describe('UsersService', () => {
         where: { id: 'user-id' },
       });
       expect(userRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({ fcmToken: 'new-token' }),
+        expect.objectContaining({ fcmToken: 'new-token' })
       );
       expect(result.fcmToken).toBe('new-token');
     });
@@ -100,8 +102,57 @@ describe('UsersService', () => {
       userRepository.findOne.mockResolvedValue(null);
 
       await expect(service.registerDeviceToken('user-id', 'token')).rejects.toThrow(
-        NotFoundException,
+        NotFoundException
       );
+    });
+  });
+
+  describe('cleanupOldStatusLogs', () => {
+    it('should delete only logs older than the retention period', async () => {
+      const retentionDays = 90;
+      const expectedCutoff = new Date();
+      expectedCutoff.setDate(expectedCutoff.getDate() - retentionDays);
+
+      userStatusLogRepository.delete.mockResolvedValue({ affected: 3 } as any);
+
+      const result = await service.cleanupOldStatusLogs(retentionDays);
+
+      expect(userStatusLogRepository.delete).toHaveBeenCalledTimes(1);
+      const whereArg = userStatusLogRepository.delete.mock.calls[0][0] as {
+        createdAt: FindOperator<Date>;
+      };
+      expect(Object.keys(whereArg)).toEqual(['createdAt']);
+      expect(whereArg.createdAt).toBeInstanceOf(FindOperator);
+      expect(whereArg.createdAt.type).toBe('lessThan');
+      const cutoff = whereArg.createdAt.value as Date;
+      expect(Math.abs(cutoff.getTime() - expectedCutoff.getTime())).toBeLessThan(2000);
+      expect(result).toBe(3);
+    });
+
+    it('should never touch records newer than the retention period', async () => {
+      userStatusLogRepository.delete.mockResolvedValue({ affected: 0 } as any);
+
+      await service.cleanupOldStatusLogs(30);
+
+      const whereArg = userStatusLogRepository.delete.mock.calls[0][0] as {
+        createdAt: FindOperator<Date>;
+      };
+      // A single, strictly-less-than cutoff: rows at/after the cutoff are excluded.
+      expect(Object.keys(whereArg)).toEqual(['createdAt']);
+      expect(whereArg.createdAt).toBeInstanceOf(FindOperator);
+      expect(whereArg.createdAt.type).toBe('lessThan');
+    });
+
+    it('should return the number of deleted records', async () => {
+      userStatusLogRepository.delete.mockResolvedValue({ affected: 7 } as any);
+
+      await expect(service.cleanupOldStatusLogs(90)).resolves.toBe(7);
+    });
+
+    it('should return 0 when affected count is undefined', async () => {
+      userStatusLogRepository.delete.mockResolvedValue({} as any);
+
+      await expect(service.cleanupOldStatusLogs(90)).resolves.toBe(0);
     });
   });
 
@@ -109,29 +160,43 @@ describe('UsersService', () => {
     it('updates user profile fields', async () => {
       const user = {
         id: 'user-1',
-        name: 'Old Name',
-        phone: '111111111',
+        email: 'test@example.com',
+        firstName: 'Old',
+        lastName: 'Name',
+        fullName: 'Old Name',
+        phoneNumber: '111111111',
         address: 'Old Address',
-      };
+        walletAddress: null,
+        referralCode: null,
+        preferredLanguage: 'en',
+        country: 'US',
+      } as any;
 
-      userRepository.findOne.mockResolvedValue(user as any);
+      userRepository.findOne.mockResolvedValueOnce(user).mockResolvedValueOnce({
+        ...user,
+        firstName: 'New',
+        fullName: 'New Name',
+      } as any);
+
       userRepository.save.mockResolvedValue({
         ...user,
-        name: 'New Name',
+        firstName: 'New',
+        fullName: 'New Name',
       } as any);
 
       const result = await service.updateProfile('user-1', {
-        name: 'New Name',
+        firstName: 'New',
       } as any);
 
-      expect((result as any).name).toBe('New Name');
+      expect(result.firstName).toBe('New');
+      expect(result.fullName).toBe('New Name');
     });
 
     it('throws when user does not exist', async () => {
       userRepository.findOne.mockResolvedValue(null);
 
       await expect(service.updateProfile('missing-user', {} as any)).rejects.toThrow(
-        NotFoundException,
+        NotFoundException
       );
     });
   });

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -6,7 +6,7 @@ import {
   Inject,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { LessThan, Repository } from 'typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { User } from '../../entities/user.entity';
@@ -38,8 +38,6 @@ export class UsersService {
     private readonly userStatusLogRepository: Repository<UserStatusLog>,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     private readonly preferencesService: PreferencesService
-    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache = null as any,
-    private readonly preferencesService: PreferencesService = null as any,
   ) {}
 
   async registerDeviceToken(userId: string, token: string): Promise<User> {
@@ -400,6 +398,27 @@ export class UsersService {
     };
   }
 
+  /**
+   * Permanently deletes {@link UserStatusLog} records older than the given
+   * retention period.
+   *
+   * Only records whose `createdAt` predates `now - retentionDays` are removed;
+   * records newer than (or equal to) the cutoff are never touched.
+   *
+   * @param retentionDays how many days of status-log history to keep
+   * @returns the number of deleted records
+   */
+  async cleanupOldStatusLogs(retentionDays: number): Promise<number> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - retentionDays);
+
+    const result = await this.userStatusLogRepository.delete({
+      createdAt: LessThan(cutoff),
+    });
+
+    return result.affected ?? 0;
+  }
+
   async canUserLogin(userId: string): Promise<{ canLogin: boolean; reason?: string }> {
     const user = await this.userRepository.findOne({ where: { id: userId } });
     if (!user) return { canLogin: false, reason: 'User not found' };
@@ -476,7 +495,7 @@ export class UsersService {
 
     if (updateProfileDto.phoneNumber !== undefined) {
       const normalizedPhone = PhoneValidationUtil.normalizePhoneNumber(
-        updateProfileDto.phoneNumber,
+        updateProfileDto.phoneNumber
       );
       if (!normalizedPhone) {
         throw new BadRequestException('Invalid phone format');
@@ -669,58 +688,5 @@ export class UsersService {
     if (this.cacheManager) {
       await this.cacheManager.del(`user:profile:${userId}`);
     }
-  async updateProfile(
-    userId: string,
-    dto: UpdateProfileDto,
-  ) {
-
-    const user =
-      await this.userRepository.findOne({
-        where: {
-          id: userId,
-        },
-      });
-
-    if (!user) {
-      throw new NotFoundException(
-        'User not found',
-      );
-    }
-
-    Object.assign(
-      user,
-      {
-        name:
-          dto.name ??
-          user.name,
-
-        phone:
-          dto.phone ??
-          user.phone,
-
-        address:
-          dto.address ??
-          user.address,
-      },
-    );
-
-    const updatedUser =
-      await this.userRepository.save(
-        user,
-      );
-
-    return {
-      id:
-        updatedUser.id,
-
-      name:
-        updatedUser.name,
-
-      phone:
-        updatedUser.phone,
-
-      address:
-        updatedUser.address,
-    };
   }
 }


### PR DESCRIPTION
## Description

Completes #1048 — unit tests for the cleanup scheduler in the shared scheduler module.

`cleanup.scheduler.spec.ts` already covered the scheduler's retention-period handling, but the underlying `UsersService.cleanupOldStatusLogs` method it depends on did not exist, and no test verified that cleanup only targets the correct records. This PR implements that method and adds the missing coverage.

## Scope

### In Scope
- Implement `UsersService.cleanupOldStatusLogs(retentionDays)` — deletes only `UserStatusLog` rows whose `createdAt` predates `now - retentionDays`.
- Add `cleanupOldStatusLogs` unit tests verifying correct identification of cleanup targets.
- Add a test explicitly verifying non-target (newer) records are never touched.
- Fix the broken `UsersService` constructor (duplicate parameters from a bad merge) and remove stale dead code so the module compiles and its existing spec can run.

### Out of Scope
- Changing the cleanup retention period.

## Files
- `src/modules/users/users.service.ts`
- `src/modules/users/users.service.spec.ts`

## Acceptance Criteria
- [x] Spec file added
- [x] Test explicitly verifies non-target records are untouched
- [x] `npm run test` passes

## How to Test
```
npm run test -- cleanup
```

### Test results
`cleanup.scheduler.spec.ts` — 7 passed

```
Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
```

`users.service.spec.ts` — 10 passed

```
Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
```

## PR Requirements
- [x] `npm run test` passes
- CI checks pass (tests above)

Closes #1048
