### PR TITLE
Add unit tests for reference service country/language data

### DIFF
--- a/src/reference/reference.service.spec.ts
+++ b/src/reference/reference.service.spec.ts
@@ -1,56 +1,129 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ReferenceService } from './reference.service';
+import { MetricsService } from '../shared/metrics/metrics.service';
+import { AFRICAN_COUNTRIES } from './data/african-countries';
+import { SUPPORTED_LANGUAGES } from './data/supported-languages';
+import { SUPPORTED_LANGUAGES as LEGACY_SUPPORTED_LANGUAGES } from './data/languages';
 
-const mockCacheManager = {
-  get: jest.fn(),
-  set: jest.fn(),
+// Mock the redis client so no real Redis connection is needed in tests
+jest.mock('redis', () => {
+  return {
+    createClient: jest.fn(() => ({
+      connect: jest.fn().mockResolvedValue(undefined),
+      get: jest.fn(),
+      setEx: jest.fn(),
+      del: jest.fn(),
+      quit: jest.fn(),
+    })),
+  };
+});
+
+const mockMetricsService = {
+  incrementCacheHits: jest.fn(),
+  incrementCacheMisses: jest.fn(),
 };
 
 describe('ReferenceService - getLanguages', () => {
   let service: ReferenceService;
+  let redisClient: any;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReferenceService,
-        { provide: CACHE_MANAGER, useValue: mockCacheManager },
+        { provide: MetricsService, useValue: mockMetricsService },
       ],
     }).compile();
 
     service = module.get<ReferenceService>(ReferenceService);
+    redisClient = (service as any).redisClient;
     jest.clearAllMocks();
   });
 
   it('should return all 12 languages', async () => {
-    mockCacheManager.get.mockResolvedValue(null);
-    const result = await service.getLanguages() as any;
-    expect(result.total).toBe(12);
-    expect(result.languages).toHaveLength(12);
+    redisClient.get.mockResolvedValue(null);
+    const result = await service.getLanguages();
+    expect(result).toHaveLength(12);
   });
 
   it('should mark Arabic as RTL', async () => {
-    mockCacheManager.get.mockResolvedValue(null);
-    const result = await service.getLanguages() as any;
-    const arabic = result.languages.find((l: any) => l.code === 'ar');
+    redisClient.get.mockResolvedValue(null);
+    const result = await service.getLanguages();
+    const arabic = result.find((l: any) => l.code === 'ar');
     expect(arabic.rtl).toBe(true);
   });
 
   it('should return cached result on second call', async () => {
-    const cached = { total: 12, languages: [] };
-    mockCacheManager.get.mockResolvedValue(cached);
+    const cached = JSON.stringify([{ code: 'en', name: 'English' }]);
+    redisClient.get.mockResolvedValue(cached);
     const result = await service.getLanguages();
-    expect(result).toEqual(cached);
-    expect(mockCacheManager.set).not.toHaveBeenCalled();
+    expect(result).toEqual([{ code: 'en', name: 'English' }]);
+    expect(redisClient.setEx).not.toHaveBeenCalled();
   });
 
   it('should cache result for 1 hour on first call', async () => {
-    mockCacheManager.get.mockResolvedValue(null);
+    redisClient.get.mockResolvedValue(null);
     await service.getLanguages();
-    expect(mockCacheManager.set).toHaveBeenCalledWith(
+    expect(redisClient.setEx).toHaveBeenCalledWith(
       'reference:languages',
-      expect.any(Object),
-      3600000,
+      3600,
+      JSON.stringify(SUPPORTED_LANGUAGES),
     );
+  });
+});
+
+describe('Reference data integrity', () => {
+  describe('african-countries.ts', () => {
+    it('should not contain duplicate country codes', () => {
+      const codes = AFRICAN_COUNTRIES.map((c) => c.code);
+      const duplicates = codes.filter((code, index) => codes.indexOf(code) !== index);
+      expect(duplicates).toEqual([]);
+    });
+
+    it('should not contain malformed country entries', () => {
+      for (const country of AFRICAN_COUNTRIES) {
+        expect(country.code).toMatch(/^[A-Z]{2}$/);
+        expect(country.name.trim().length).toBeGreaterThan(0);
+        expect(country.flag.trim().length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('supported-languages.ts', () => {
+    it('should not contain duplicate language codes', () => {
+      const codes = SUPPORTED_LANGUAGES.map((l) => l.code);
+      const duplicates = codes.filter((code, index) => codes.indexOf(code) !== index);
+      expect(duplicates).toEqual([]);
+    });
+
+    it('should not contain malformed language entries', () => {
+      for (const language of SUPPORTED_LANGUAGES) {
+        expect(language.code).toMatch(/^[a-z]{2}$/);
+        expect(language.name.trim().length).toBeGreaterThan(0);
+        expect(language.nativeName.trim().length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('languages.ts', () => {
+    it('should not contain duplicate language codes', () => {
+      const codes = LEGACY_SUPPORTED_LANGUAGES.map((l) => l.code);
+      const duplicates = codes.filter((code, index) => codes.indexOf(code) !== index);
+      expect(duplicates).toEqual([]);
+    });
+
+    it('should not contain malformed language entries', () => {
+      for (const language of LEGACY_SUPPORTED_LANGUAGES) {
+        expect(language.code).toMatch(/^[a-z]{2}$/);
+        expect(language.name.trim().length).toBeGreaterThan(0);
+        expect(language.nativeName.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should expose the same language codes as supported-languages.ts (redundant file check)', () => {
+      const activeCodes = SUPPORTED_LANGUAGES.map((l) => l.code).sort();
+      const legacyCodes = LEGACY_SUPPORTED_LANGUAGES.map((l) => l.code).sort();
+      expect(legacyCodes).toEqual(activeCodes);
+    });
   });
 });


### PR DESCRIPTION


## Relationship between languages.ts and supported-languages.ts

`src/reference/data/languages.ts` is a **redundant legacy duplicate** of `src/reference/data/supported-languages.ts`.

- Only `supported-languages.ts` is imported anywhere in the codebase (`reference.service.ts` and `reference.controller.ts`). `languages.ts` is referenced by no source file.
- `languages.ts` is untyped (no `Language` interface) and differs only cosmetically: it sets `rtl: false` explicitly on every entry and uses different native-name spellings (e.g. Amharic `አማርኛ` vs `Amharic`, Zulu `isiZulu` vs `Zulu`, Somali `Soomaali` vs `Somali`).
- Both files expose the exact same 12 language codes; a new test asserts this so the duplicate cannot drift.

Recommendation: remove `languages.ts` and keep `supported-languages.ts` as the single source of truth (left as a follow-up to keep this change focused on tests).

## Test results

`npm run test -- reference` → **4 suites passed, 44 tests passed** (previously 1 suite / 4 tests were failing on `main` because the spec asserted a `{ total, languages }` shape the service no longer returns and omitted the required `MetricsService` provider).

```
Test Suites: 4 passed, 4 total
Tests:       44 passed, 44 total
```

Closes #1062
