### PR TITLE
docs: add JSDoc to AuditLog entity

### DIFF
--- a/src/audit/entities/audit-log.entity.ts
+++ b/src/audit/entities/audit-log.entity.ts
@@ -1,3 +1,9 @@
+/**
+ * Represents an immutable audit log entry recording user and system actions,
+ * including the affected resource, request context, changes, and compliance
+ * metadata.
+ */
+
 import {
   Entity,
   Column,
@@ -108,7 +114,7 @@ export class AuditLog {
   @Column({ type: 'jsonb', nullable: true })
   metadata: Record<string, any> | null;
 
-  @CreateDateColumn({ 
+  @CreateDateColumn({
     type: 'timestamp with time zone',
     name: 'created_at',
     precision: 6,


### PR DESCRIPTION
## Description
Adds a class-level JSDoc comment to the AuditLog TypeORM entity, describing what the entity represents and the type of audit information it stores.

Closes #1200

## Type of Change
<!-- Check all that apply. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [x] Documentation update
- [ ] CI/CD or configuration change

## How Has This Been Tested?
<!-- Describe the tests you ran and how to reproduce them. -->
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
 The change is documentation-only and does not modify runtime behavior.

## Checklist
- [x] My code follows the project's style guidelines (`npm run lint` passes)
- [x] I have performed a self-review of my code
- [ ] I have added or updated tests that cover my changes
- [x] All existing tests pass (`npm run test`)
- [x] I have updated relevant documentation (README, JSDoc, etc.)
- [x] No secrets or sensitive data are included in this PR
- [x] The branch is up to date with `main`

## Screenshots / Logs (if applicable)
<!-- Attach any relevant screenshots, API responses, or log output. -->
