### PR TITLE
refactor: use ConfigService in storage service

### DIFF
--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -7,6 +7,7 @@ import {
   GetObjectCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class StorageService {
@@ -14,10 +15,12 @@ export class StorageService {
   private readonly logger = new Logger(StorageService.name);
   private bucketName: string;
 
-  constructor() {
-    const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
-    const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
-    this.bucketName = process.env.AWS_S3_BUCKET_NAME || '';
+  constructor(
+    private readonly configService: ConfigService,
+  ) {
+    const accessKeyId = this.configService.get<string>('AWS_ACCESS_KEY_ID');
+    const secretAccessKey = this.configService.get<string>('AWS_SECRET_ACCESS_KEY');
+    this.bucketName = this.configService.get<string>('AWS_S3_BUCKET_NAME') || '';
 
     if (!accessKeyId || !secretAccessKey) {
       this.logger.error('AWS Credentials are missing from environment variables!');
@@ -25,12 +28,12 @@ export class StorageService {
     }
 
     this.s3Client = new S3Client({
-      region: process.env.AWS_REGION || 'us-east-1',
+      region: this.configService.get<string>('AWS_REGION') || 'us-east-1',
       credentials: {
         accessKeyId,
         secretAccessKey,
       },
-      endpoint: process.env.AWS_S3_ENDPOINT,
+      endpoint: this.configService.get<string>('AWS_S3_ENDPOINT'),
       forcePathStyle: true,
     });
   }


### PR DESCRIPTION
## Description
Refactored `StorageService` to use NestJS `ConfigService` instead of accessing environment variables directly through `process.env`.

Closes #1135

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] CI/CD or configuration change

## How Has This Been Tested?
<!-- Describe the tests you ran and how to reproduce them. -->
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the project's style guidelines (`npm run lint` passes)
- [x] I have performed a self-review of my code
- [ ] I have added or updated tests that cover my changes
- [ ] All existing tests pass (`npm run test`)
- [ ] I have updated relevant documentation (README, JSDoc, etc.)
- [x] No secrets or sensitive data are included in this PR
- [x] The branch is up to date with `main`
