### PR TITLE
Add @ApiOperation Swagger decorators to task-completion and gamification controllers

### DIFF
--- a/src/modules/gamification/gamification.controller.ts
+++ b/src/modules/gamification/gamification.controller.ts
@@ -1,8 +1,11 @@
 import { Controller, Get, Post, Body, Param, UseGuards, Request, HttpStatus, HttpCode } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GamificationService } from './gamification.service';
 import { AchievementService } from './achievement.service';
 import { AwardXpDto, XpStatusDto } from './dto/xp-status.dto';
 
+@ApiTags('Gamification')
+@ApiBearerAuth()
 @Controller('gamification')
 export class GamificationController {
   constructor(
@@ -11,12 +14,14 @@ export class GamificationController {
   ) {}
 
   @Get('status/:userId')
+  @ApiOperation({ summary: 'Get XP status for a user' })
   async getXpStatus(@Param('userId') userId: string): Promise<XpStatusDto> {
     return this.gamificationService.getUserXpStatus(userId);
   }
 
   @Post('award')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Award XP to a user' })
   async awardXp(@Body() awardXpDto: AwardXpDto): Promise<{
     xpStatus: XpStatusDto;
     leveledUp: boolean;
@@ -26,28 +31,33 @@ export class GamificationController {
   }
 
   @Get('transactions/:userId')
+  @ApiOperation({ summary: 'Get XP transaction history for a user' })
   async getTransactions(@Param('userId') userId: string) {
     return this.gamificationService.getXpTransactions(userId);
   }
 
   @Get('achievements')
+  @ApiOperation({ summary: 'Get all available achievements' })
   async getAllAchievements() {
     return this.gamificationService.getAchievements();
   }
 
   @Get('achievements/:userId')
+  @ApiOperation({ summary: 'Get achievements earned by a user' })
   async getUserAchievements(@Param('userId') userId: string) {
     return this.gamificationService.getUserAchievements(userId);
   }
 
   @Post('achievements/check/:userId')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Check and update achievements for a user' })
   async checkAchievements(@Param('userId') userId: string) {
     return this.achievementService.checkAchievements(userId);
   }
 
   @Post('achievements/unlock/:userId/:achievementKey')
   @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Manually unlock an achievement for a user' })
   async unlockAchievement(
     @Param('userId') userId: string,
     @Param('achievementKey') achievementKey: string,

--- a/src/tasks/completions/task-completion.controller.ts
+++ b/src/tasks/completions/task-completion.controller.ts
@@ -7,10 +7,13 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { TaskCompletionService } from './task-completion.service';
 import { CompleteTaskDto } from './dto/complete-task.dto';
 import { JwtAuthGuard } from '@modules/auth/guards/jwt-auth.guard';
 import { StorageService } from '../../storage/storage.service';
+@ApiTags('Task Completions')
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('tasks/completions')
 export class TaskCompletionController {
@@ -20,22 +23,26 @@ export class TaskCompletionController {
   ) {}
 
   @Post()
+  @ApiOperation({ summary: 'Complete a task and earn rewards' })
   completeTask(@Req() req: any, @Body() dto: CompleteTaskDto) {
     // req.user.id comes from JwtStrategy's validate() return value
     return this.service.completeTask(req.user.id, dto);
   }
 
   @Get('my')
+  @ApiOperation({ summary: 'Get current user\'s task completions' })
   getMyCompletions(@Req() req: any) {
     return this.service.getUserCompletions(req.user.id);
   }
 
   @Get('stats')
+  @ApiOperation({ summary: 'Get current user\'s completion statistics' })
   getStats(@Req() req: any) {
     return this.service.getUserCompletionStats(req.user.id);
   }
 
   @Post(':id/proof-upload-url')
+  @ApiOperation({ summary: 'Generate a presigned upload URL for task proof' })
   getProofUploadUrl(
     @Req() req: any,
     @Param('id') taskId: string,


### PR DESCRIPTION
This PR adds missing @ApiOperation decorators to all route handlers in the task-completion and gamification controllers, so the generated Swagger API docs include proper summaries for each endpoint.

Changes:
- **task-completion.controller.ts**: Added @ApiOperation, @ApiTags, and @ApiBearerAuth decorators to all 4 endpoints
- **gamification.controller.ts**: Added @ApiOperation, @ApiTags, and @ApiBearerAuth decorators to all 7 endpoints

Closes #1147
Closes #1144