### PR TITLE
Add @ApiOperation decorators to healer controller and use ConfigService in auth.service.ts

### DIFF
--- a/src/modules/auth/healer.controller.ts
+++ b/src/modules/auth/healer.controller.ts
@@ -1,20 +1,25 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RolesGuard } from './guards/roles.guard';
 import { Roles } from './decorators/roles.decorator';
 import { Role } from './enums/role.enum';
 
+@ApiTags('Healer')
+@ApiBearerAuth()
 @Controller('healer')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class HealerController {
   @Get('dashboard')
   @Roles(Role.HEALER, Role.ADMIN)
+  @ApiOperation({ summary: 'Get healer or admin dashboard' })
   getDashboard() {
     return { message: 'Welcome healer or admin' };
   }
 
   @Get('admin-only')
   @Roles(Role.ADMIN)
+  @ApiOperation({ summary: 'Get admin-only endpoint' })
   getAdmin() {
     return { message: 'Admin only endpoint' };
   }

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -9,6 +9,7 @@ import {
   Optional,
   UnauthorizedException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { authenticator } from 'otplib';
 import * as qrcode from 'qrcode';
 import { AccountLockedException } from '../exceptions/account-locked.exception';
@@ -41,14 +42,8 @@ export class AuthService {
   private redisClient: RedisClientType;
   private readonly blacklistCache = new Map<string, { blacklisted: boolean; expiresAt: number }>();
   private readonly CACHE_TTL = 5 * 60 * 1000; // 5 minutes
-  private readonly maxFailedLoginAttempts = parseInt(
-    process.env.MAX_FAILED_LOGIN_ATTEMPTS || '5',
-    10,
-  );
-  private readonly lockoutDurationMs = parseInt(
-    process.env.ACCOUNT_LOCKOUT_DURATION_MS || String(15 * 60 * 1000),
-    10,
-  );
+  private readonly maxFailedLoginAttempts: number;
+  private readonly lockoutDurationMs: number;
 
   constructor(
     private usersService: UsersService,
@@ -62,10 +57,13 @@ export class AuthService {
     @InjectRepository(TokenBlacklist)
     private tokenBlacklistRepo: Repository<TokenBlacklist>,
     private readonly notifications: NotificationService,
+    private readonly configService: ConfigService,
     @Optional() private readonly referralService?: ReferralService,
   ) {
+    this.maxFailedLoginAttempts = this.configService.get<number>('MAX_FAILED_LOGIN_ATTEMPTS', 5);
+    this.lockoutDurationMs = this.configService.get<number>('ACCOUNT_LOCKOUT_DURATION_MS', 15 * 60 * 1000);
     this.redisClient = createClient({
-      url: process.env.REDIS_URL || 'redis://localhost:6379',
+      url: this.configService.get<string>('REDIS_URL', 'redis://localhost:6379'),
     });
     this.redisClient.connect();
   }
@@ -633,7 +631,7 @@ export class AuthService {
     this.logger.log(`Password reset requested for: ${email}`);
 
     try {
-      const resetLink = `${process.env.FRONTEND_URL || 'https://example.com'}/reset-password?token=${token}`;
+      const resetLink = `${this.configService.get<string>('FRONTEND_URL', 'https://example.com')}/reset-password?token=${token}`;
       await this.notifications.sendEmail(user.id, 'password-reset', {
         name: user.firstName || user.email,
         link: resetLink,


### PR DESCRIPTION
This PR addresses two issues:

1. **@ApiOperation decorators (#1143)**: Added @ApiOperation, @ApiTags, and @ApiBearerAuth decorators to the healer controller endpoints so they appear correctly in Swagger documentation.

2. **ConfigService migration (#1142)**: Replaced direct process.env access with NestJS's ConfigService in uth.service.ts for MAX_FAILED_LOGIN_ATTEMPTS, ACCOUNT_LOCKOUT_DURATION_MS, REDIS_URL, and FRONTEND_URL. This improves testability and ensures config validation/defaults from the config module are respected.

Closes #1143
Closes #1142