### PR TITLE
Add @ApiOperation Swagger decorators to streaks.controller.ts

### DIFF
--- a/src/streaks/streaks.controller.ts
+++ b/src/streaks/streaks.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '@modules/auth/guards/jwt-auth.guard';
 import { StreaksService } from './streaks.service';
 
@@ -11,12 +11,14 @@ export class StreaksController {
   constructor(private readonly streaksService: StreaksService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Get current streak for the authenticated user' })
   async getCurrentStreak(@Req() req: any) {
     const userId = req.user?.id || req.user?.userId || req.user?.sub;
     return this.streaksService.getCurrentStreak(userId);
   }
 
   @Get('me')
+  @ApiOperation({ summary: 'Get my streak summary' })
   async getMyStreak(@Req() req: any) {
     const userId = req.user?.id || req.user?.userId || req.user?.sub;
     const streak = await this.streaksService.getCurrentStreak(userId);
@@ -28,6 +30,7 @@ export class StreaksController {
   }
 
   @Get('history')
+  @ApiOperation({ summary: 'Get streak history for the authenticated user' })
   async getHistory(@Req() req: any) {
     const userId = req.user?.id || req.user?.userId || req.user?.sub;
     return this.streaksService.getStreakHistory(userId);


### PR DESCRIPTION
This PR adds missing @ApiOperation decorators to all route handlers in the streaks controller, so the generated Swagger API docs include proper summaries for each endpoint.

Changes:
- **streaks.controller.ts**: Added @ApiOperation decorators with descriptive summaries to all 3 endpoints (getCurrentStreak, getMyStreak, getHistory). Also imported ApiOperation from @nestjs/swagger.

Closes #1145