### PR TITLE
refactor(middleware): use ConfigService instead of process.env in csrf.middleware.ts

### DIFF
--- a/src/common/middleware/csrf.middleware.ts
+++ b/src/common/middleware/csrf.middleware.ts
@@ -1,4 +1,5 @@
 import { Injectable, NestMiddleware, ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Request, Response, NextFunction } from 'express';
 import * as crypto from 'crypto';
 
@@ -8,13 +9,15 @@ export class CsrfMiddleware implements NestMiddleware {
   private readonly cookieName = 'csrf-token';
   private readonly headerName = 'x-csrf-token';
 
+  constructor(private readonly configService: ConfigService) {}
+
   use(req: Request, res: Response, next: NextFunction) {
     // Generate CSRF token for new sessions
     if (!req.cookies[this.cookieName]) {
       const token = this.generateToken();
       res.cookie(this.cookieName, token, {
         httpOnly: false, // Allow JavaScript access for SPAs
-        secure: process.env.NODE_ENV === 'production',
+        secure: this.configService.get<string>('NODE_ENV') === 'production',
         sameSite: 'strict',
         maxAge: 24 * 60 * 60 * 1000, // 24 hours
       });


### PR DESCRIPTION
Closes #1140

PR Description:
Refactored `CsrfMiddleware` to use NestJS's `ConfigService` instead of directly accessing `process.env`. This ensures proper validation and defaults defined in the config module and improves testability and mocking.

Type of Change:
 [x] Refactor / code cleanup

How Has This Been Tested:
 [x] Manual testing (verified environment variable retrieval via ConfigService)

Checklist:
 [x] My code follows the project's style guidelines (`npm run lint` passes)
 [x] I have performed a self-review of my code
 [x] All existing tests pass (`npm run test`)
 [x] No secrets or sensitive data are included in this PR
 [x] The branch is up to date with `main`

