### PR TITLE
fix: replace any type with TaskTag[] in health-task.entity.ts

### DIFF
--- a/src/tasks/entities/health-task.entity.ts
+++ b/src/tasks/entities/health-task.entity.ts
@@ -11,6 +11,7 @@ import {
   JoinTable,
 } from 'typeorm';
 import { TaskCategory as TaskCategoryEntity } from '../../database/entities/task-category.entity';
+import type { TaskTag } from '../../database/entities/task-tag.entity';
 
 export enum TaskCategory {
   NUTRITION = 'nutrition',
@@ -63,7 +64,7 @@ export class HealthTask {
     joinColumn: { name: 'healthTaskId', referencedColumnName: 'id' },
     inverseJoinColumn: { name: 'tagId', referencedColumnName: 'id' },
   })
-  tags?: any[];
+  tags?: TaskTag[];
 
   @Column({ type: 'varchar', nullable: true })
   createdBy!: string | null;


### PR DESCRIPTION
## Summary
- Replaces the `any[]` type on `HealthTask.tags` (src/tasks/entities/health-task.entity.ts:66) with the actual related entity type `TaskTag[]`, imported via `import type` to avoid runtime circular-import issues between `HealthTask` and `TaskTag`.

Closes #1099

## Test plan
- [x] `tsc --noEmit` passes with no new errors for this file