### PR TITLE
fix: replace any type with PriorityAlert interface in health-tasks.service.ts

### DIFF
--- a/src/modules/health-tasks/health-tasks.service.ts
+++ b/src/modules/health-tasks/health-tasks.service.ts
@@ -16,6 +16,12 @@ import { ActivityLogService } from './services/activity-log.service';
 import { TaskCategory } from '../../database/entities/task-category.entity';
 import { TaskTag } from '../../database/entities/task-tag.entity';
 
+interface PriorityAlert {
+  type: string;
+  message: string;
+  createdAt: string;
+}
+
 @Injectable()
 export class HealthTasksService {
   constructor(
@@ -131,11 +137,14 @@ export class HealthTasksService {
     const alertMessage = this.priorityService.buildOverdueAlert(prioritizableTask);
     if (alertMessage) {
       const existingProfile = task.targetProfile ?? {};
-      const priorityAlerts = Array.isArray((existingProfile as any).priorityAlerts)
+      const priorityAlerts: PriorityAlert[] = Array.isArray(
+        (existingProfile as any).priorityAlerts,
+      )
         ? [...(existingProfile as any).priorityAlerts]
         : [];
       const alreadyPresent = priorityAlerts.some(
-        (alert: any) => alert?.type === 'overdue' && alert?.message === alertMessage,
+        (alert: PriorityAlert) =>
+          alert?.type === 'overdue' && alert?.message === alertMessage,
       );
       if (!alreadyPresent) {
         priorityAlerts.push({


### PR DESCRIPTION
## Summary
- Replaces the `any` type usage in `src/modules/health-tasks/health-tasks.service.ts` with a proper `PriorityAlert` interface for priority alert objects.

## Test plan
- [x] `npx tsc --noEmit` passes with no new type errors

Closes #1098