### PR TITLE
Return full user settings, fix admin user tasks endpoint, add missing Swagger decorators

### DIFF
--- a/src/entities/health-task.entity.ts
+++ b/src/entities/health-task.entity.ts
@@ -14,12 +14,12 @@ import { TaskCategory } from '../database/entities/task-category.entity';
 import { TaskTag } from '../database/entities/task-tag.entity';
 import { TaskDifficulty } from '../tasks/enums/task-difficulty.enum';
 
-@entity('health_tasks')
+@Entity('health_tasks')
 export class HealthTask {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @ManyToOne((): User, (user) => user.healthTasks, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, (user) => user.healthTasks, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user: User;
 
@@ -56,7 +56,7 @@ export class HealthTask {
   @Column({ default: true })
   isActive: boolean;
 
-  CCreateDateColumn()
+  @CreateDateColumn()
   createdAt: Date;
 
   @UpdateDateColumn()

--- a/src/modules/admin/services/admin-users.service.spec.ts
+++ b/src/modules/admin/services/admin-users.service.spec.ts
@@ -1,0 +1,133 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { AdminUsersService } from './admin-users.service';
+import { User } from '@/entities/user.entity';
+import { AuditService } from '@/audit/audit.service';
+import { StreaksService } from '@/streaks/streaks.service';
+import { TaskAssignmentService } from '@/tasks/assignment/task-assignment.service';
+import { Role } from '@modules/auth/enums/role.enum';
+
+describe('AdminUsersService', () => {
+  let service: AdminUsersService;
+  let usersRepository: jest.Mocked<Repository<User>>;
+  let taskAssignmentService: jest.Mocked<TaskAssignmentService>;
+
+  const mockUser = {
+    id: 'user-1',
+    email: 'user1@example.com',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    role: Role.USER,
+  } as any;
+
+  beforeEach(async () => {
+    const mockUsersRepository = {
+      findOne: jest.fn(),
+    };
+
+    const mockAuditService = {
+      logAction: jest.fn(),
+    };
+
+    const mockStreaksService = {
+      getStreakHistory: jest.fn(),
+    };
+
+    const mockTaskAssignmentService = {
+      getAssignmentHistory: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminUsersService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUsersRepository,
+        },
+        {
+          provide: AuditService,
+          useValue: mockAuditService,
+        },
+        {
+          provide: StreaksService,
+          useValue: mockStreaksService,
+        },
+        {
+          provide: TaskAssignmentService,
+          useValue: mockTaskAssignmentService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(AdminUsersService);
+    usersRepository = module.get(getRepositoryToken(User));
+    taskAssignmentService = module.get(TaskAssignmentService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getUserTasks (#1015)', () => {
+    it('returns the user summary along with their full assignment/task history', async () => {
+      usersRepository.findOne.mockResolvedValue(mockUser);
+      taskAssignmentService.getAssignmentHistory.mockResolvedValue([
+        {
+          id: 'assignment-2',
+          assignedDate: '2026-08-20',
+          tasks: [{ id: 'task-3', title: 'Drink water' }],
+        },
+        {
+          id: 'assignment-1',
+          assignedDate: '2026-08-19',
+          tasks: [
+            { id: 'task-1', title: 'Walk 5000 steps' },
+            { id: 'task-2', title: 'Sleep 8 hours' },
+          ],
+        },
+      ] as any);
+
+      const result = await service.getUserTasks('user-1');
+
+      expect(result.user).toEqual({
+        id: 'user-1',
+        email: 'user1@example.com',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        role: Role.USER,
+      });
+
+      // This is the actual gap #1015 closes: previously this was always a
+      // hardcoded empty array regardless of what the user was assigned.
+      expect(result.tasks).toHaveLength(2);
+      expect(result.tasks[0]).toEqual({
+        assignmentId: 'assignment-2',
+        assignedDate: '2026-08-20',
+        tasks: [{ id: 'task-3', title: 'Drink water' }],
+      });
+      expect(result.tasks[1].tasks).toHaveLength(2);
+
+      expect(taskAssignmentService.getAssignmentHistory).toHaveBeenCalledWith('user-1');
+    });
+
+    it('returns an empty task list for a user with no assignments, without erroring', async () => {
+      usersRepository.findOne.mockResolvedValue(mockUser);
+      taskAssignmentService.getAssignmentHistory.mockResolvedValue([]);
+
+      const result = await service.getUserTasks('user-1');
+
+      expect(result.tasks).toEqual([]);
+    });
+
+    it('throws NotFoundException (404) for an unknown user id', async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getUserTasks('missing-user')).rejects.toThrow(NotFoundException);
+
+      // Must not query assignment history for a user that doesn't exist.
+      expect(taskAssignmentService.getAssignmentHistory).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/admin/services/admin-users.service.ts
+++ b/src/modules/admin/services/admin-users.service.ts
@@ -16,6 +16,7 @@ import { Role } from '@modules/auth/enums/role.enum';
 import { UserStatus } from '@modules/auth/enums/user-status.enum';
 import { AuditService } from '@/audit/audit.service';
 import { StreaksService } from '@/streaks/streaks.service';
+import { TaskAssignmentService } from '@/tasks/assignment/task-assignment.service';
 
 /**
  * Provides admin-level user management operations including user
@@ -30,6 +31,7 @@ export class AdminUsersService {
     private readonly usersRepository: Repository<User>,
     private readonly auditService: AuditService,
     private readonly streaksService: StreaksService,
+    private readonly taskAssignmentService: TaskAssignmentService,
   ) {
     this.redisClient = createClient({
       url: process.env.REDIS_URL || 'redis://localhost:6379',
@@ -263,8 +265,10 @@ export class AdminUsersService {
     });
 
     if (!user) {
-      throw new BadRequestException('User not found');
+      throw new NotFoundException('User not found');
     }
+
+    const assignments = await this.taskAssignmentService.getAssignmentHistory(userId);
 
     return {
       user: {
@@ -274,7 +278,11 @@ export class AdminUsersService {
         lastName: user.lastName,
         role: user.role,
       },
-      tasks: [],
+      tasks: assignments.map((assignment) => ({
+        assignmentId: assignment.id,
+        assignedDate: assignment.assignedDate,
+        tasks: assignment.tasks,
+      })),
     };
   }
 }

--- a/src/modules/auth/dto/link-wallet.dto.ts
+++ b/src/modules/auth/dto/link-wallet.dto.ts
@@ -1,6 +1,11 @@
 import { IsString, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LinkWalletDto {
+  @ApiProperty({
+    example: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW',
+    description: 'The Stellar public address to link to the user account',
+  })
   @IsString()
   @Matches(/^G[A-Z2-7]{55}$/, {
     message: 'Invalid Stellar address format',

--- a/src/modules/users/dto/preferences.dto.ts
+++ b/src/modules/users/dto/preferences.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional, IsEnum, IsBoolean, IsObject, IsNumber, Matches, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
-import { Theme, NotificationType } from '../../database/entities/user-preferences.entity';
+import { Theme, NotificationType } from '../../../database/entities/user-preferences.entity';
 
 export class NotificationPreferencesDto {
   @ApiPropertyOptional({

--- a/src/modules/users/dto/user-settings.dto.ts
+++ b/src/modules/users/dto/user-settings.dto.ts
@@ -9,6 +9,11 @@ import {
 } from 'class-validator';
 
 import { Transform } from 'class-transformer';
+import { Theme } from '../../../database/entities/user-preferences.entity';
+import {
+    NotificationPreferencesDto,
+    PrivacyPreferencesDto,
+} from './preferences.dto';
 
 export const SUPPORTED_LANGUAGE_CODES = [
     'en',
@@ -88,6 +93,37 @@ export class UserSettingsResponseDto {
         default: null,
     })
     phoneNumber!: string | null;
+
+    @ApiPropertyOptional({
+        description: 'UI theme preference',
+        enum: Theme,
+        example: Theme.SYSTEM,
+    })
+    theme?: Theme;
+
+    @ApiPropertyOptional({
+        description: 'Email notification preferences',
+        type: NotificationPreferencesDto,
+    })
+    emailNotifications?: NotificationPreferencesDto;
+
+    @ApiPropertyOptional({
+        description: 'Push notification preferences',
+        type: NotificationPreferencesDto,
+    })
+    pushNotifications?: NotificationPreferencesDto;
+
+    @ApiPropertyOptional({
+        description: 'SMS notification preferences',
+        type: NotificationPreferencesDto,
+    })
+    smsNotifications?: NotificationPreferencesDto;
+
+    @ApiPropertyOptional({
+        description: 'Privacy settings',
+        type: PrivacyPreferencesDto,
+    })
+    privacy?: PrivacyPreferencesDto;
 }
 
 export class UpdateUserSettingsDto {

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -200,4 +200,70 @@ describe('UsersService', () => {
       );
     });
   });
+
+  describe('getSettings', () => {
+    const mockPreferences = {
+      id: 'prefs-1',
+      theme: 'dark',
+      language: 'en',
+      notifications: {
+        email: { enabled: true, tasks: true, rewards: true, streaks: true, referrals: true, system: true },
+        push: { enabled: true, tasks: false, rewards: true, streaks: true, referrals: false, system: true },
+        sms: { enabled: false, tasks: false, rewards: false, streaks: false, referrals: false, system: false },
+      },
+      privacy: {
+        profileVisibility: 'private',
+        showStats: false,
+        showStreak: true,
+        showRank: false,
+      },
+    } as any;
+
+    it('returns full settings including preferences, notifications, and privacy (#1013)', async () => {
+      userRepository.findOne.mockResolvedValue(mockUser);
+      (service as any).preferencesService.getPreferences.mockResolvedValue(mockPreferences);
+
+      const result = await service.getSettings('user-id');
+
+      // Base profile fields (already covered before #1013).
+      expect(result.fullName).toBe('John Doe');
+      expect(result.preferredLanguage).toBe('en');
+      expect(result.country).toBe('US');
+
+      // Preferences / notification channels / privacy settings - the gap
+      // #1013 closes. Before this fix, getSettings never called
+      // preferencesService at all, so these were always missing.
+      expect(result.theme).toBe('dark');
+      expect(result.emailNotifications).toEqual(mockPreferences.notifications.email);
+      expect(result.pushNotifications).toEqual(mockPreferences.notifications.push);
+      expect(result.smsNotifications).toEqual(mockPreferences.notifications.sms);
+      expect(result.privacy).toEqual(mockPreferences.privacy);
+
+      expect((service as any).preferencesService.getPreferences).toHaveBeenCalledWith('user-id');
+    });
+
+    it('creates and returns default preferences for a user who never customized them', async () => {
+      userRepository.findOne.mockResolvedValue(mockUser);
+      // PreferencesService.getPreferences already creates defaults on first
+      // access internally, so a brand-new user still gets a full response
+      // here rather than missing/undefined preference fields.
+      const defaultPreferences = {
+        ...mockPreferences,
+        theme: 'system',
+      };
+      (service as any).preferencesService.getPreferences.mockResolvedValue(defaultPreferences);
+
+      const result = await service.getSettings('user-id');
+
+      expect(result.theme).toBe('system');
+      expect(result.privacy).toEqual(defaultPreferences.privacy);
+    });
+
+    it('throws when the user does not exist', async () => {
+      userRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getSettings('missing-user')).rejects.toThrow(NotFoundException);
+      expect((service as any).preferencesService.getPreferences).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -66,7 +66,24 @@ export class UsersService {
 
   async getSettings(userId: string): Promise<UserSettingsResponseDto> {
     const user = await this.findUserOrFail(userId);
-    return this.toSettingsResponse(user);
+    const baseSettings = this.toSettingsResponse(user);
+
+    // Enrich with preferences/notification/privacy data so this endpoint
+    // returns the user's *full* settings in one call (#1013). This only
+    // affects the GET response - updateSettings/patchPreferences below
+    // are unchanged and continue to return just the profile fields, since
+    // writing these preference fields through this endpoint is a
+    // separate, out-of-scope PATCH endpoint issue.
+    const preferences = await this.preferencesService.getPreferences(userId);
+
+    return {
+      ...baseSettings,
+      theme: preferences.theme,
+      emailNotifications: preferences.notifications?.email,
+      pushNotifications: preferences.notifications?.push,
+      smsNotifications: preferences.notifications?.sms,
+      privacy: preferences.privacy,
+    };
   }
 
   async updateSettings(

--- a/src/tasks/assignment/task-assignment.service.ts
+++ b/src/tasks/assignment/task-assignment.service.ts
@@ -70,6 +70,23 @@ export class TaskAssignmentService {
     return assignment;
   }
 
+  // ─── Public: Get All Assignments For a User (admin lookup) ────────────
+
+  /**
+   * Returns every daily task assignment ever created for a user, most
+   * recent first, with each assignment's tasks eagerly loaded. Used by
+   * the admin "view a user's tasks" endpoint (#1015) - deliberately does
+   * not touch the Redis cache used by getTodayAssignment above, since
+   * this reads historical data rather than "today's" assignment.
+   */
+  async getAssignmentHistory(userId: string): Promise<DailyTaskAssignment[]> {
+    return this.assignmentRepo.find({
+      where: { user: { id: userId } },
+      relations: ['tasks'],
+      order: { assignedDate: 'DESC' },
+    });
+  }
+
   // ─── Private: Create Assignment ───────────────────────────────────────
 
   private async createAssignment(


### PR DESCRIPTION
Closes #1013
Closes #1015
Closes #1154
Closes #1158

This PR covers four issues together since I worked through them in the same session and they touch related areas of the users/admin modules.

#1158 — The address field on link-wallet.dto.ts had no @ApiProperty, so it showed up blank in the Swagger docs. Added one with a description and a valid-format example address.

#1154 — Looks like this got fixed already on main by someone else while I was working on it, so there's nothing left to do here, just linking it closed.

#1013 — The GET /users/me/settings endpoint already existed and was reachable, but it only ever returned basic profile fields like name and phone number. PreferencesService was already injected into UsersService but never actually called from getSettings, so none of the user's theme, notification, or privacy preferences ever made it into the response. Wired that in so the endpoint now genuinely returns the user's full settings like the issue asks. While doing this I also found preferences.dto.ts had a broken relative import path, it worked before because nothing had actually loaded those classes as real values, only as type annotations which TypeScript can silently drop. My change needed them as real values for the Swagger decorators, which is what surfaced it. Fixed the path.

#1015 — Same story, the GET /admin/users/:id/tasks endpoint existed and was properly admin-guarded, but the tasks field in the response was a hardcoded empty array, and it threw a 400 instead of a 404 for an unknown user id. Added a getAssignmentHistory method to TaskAssignmentService that actually queries a user's task assignments, wired it into the admin endpoint, and fixed the status code.

Extra fix — While running the test suite I found src/entities/health-task.entity.ts had three small typos, a lowercase @entity decorator, a malformed arrow function that used a colon instead of an arrow, and a duplicated letter on @CreateDateColumn. Together these were a hard syntax error that broke every single Jest test in the whole repo, not just the ones related to my changes. I confirmed this on a completely clean checkout of main before touching it, so it's unrelated to anything else in this PR, just something that needed fixing to actually run the test suite at all.

Ran tsc and the full relevant test suite before pushing, everything passes. Screenshots below.
<img width="1012" height="116" alt="image" src="https://github.com/user-attachments/assets/971e227a-aef7-4ddf-b2e8-d493c930a41f" />
