### PR TITLE
refactor: replace any type with specific types in cache, auth, activi…

### DIFF
--- a/src/database/entities/task-reminder.entity.ts
+++ b/src/database/entities/task-reminder.entity.ts
@@ -25,6 +25,14 @@ export enum ReminderStatus {
   CANCELLED = 'cancelled',
 }
 
+export interface DeliveryTracking {
+  error?: string;
+  timestamp?: Date | string;
+  sentAt?: Date | string;
+  status?: 'delivered' | 'failed_by_notification_service';
+  backfill?: boolean;
+}
+
 @Entity('task_reminders')
 @Index(['userId', 'remindAt'])
 @Index(['status'])
@@ -65,7 +73,7 @@ export class TaskReminder {
   status: ReminderStatus;
 
   @Column({ type: 'jsonb', nullable: true })
-  deliveryTracking: any;
+  deliveryTracking: DeliveryTracking | null;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/modules/auth/strategies/jwt-refresh.strategy.ts
+++ b/src/modules/auth/strategies/jwt-refresh.strategy.ts
@@ -3,6 +3,13 @@ import { PassportStrategy } from '@nestjs/passport';
 import { Strategy, ExtractJwt } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 
+export interface JwtRefreshPayload {
+  sub: string;
+  email: string;
+  role: string;
+  tokenId: string;
+}
+
 @Injectable()
 export class JwtRefreshStrategy extends PassportStrategy(
   Strategy,
@@ -16,7 +23,7 @@ export class JwtRefreshStrategy extends PassportStrategy(
     });
   }
 
-  async validate(payload: any) {
+  async validate(payload: JwtRefreshPayload) {
     if (!payload.tokenId) {
       throw new UnauthorizedException('Invalid refresh token');
     }

--- a/src/modules/users/services/activity-tracker.service.ts
+++ b/src/modules/users/services/activity-tracker.service.ts
@@ -17,10 +17,15 @@ interface ActivityMetadata {
   method?: string;
   statusCode?: number;
   responseTime?: number;
-  oldValues?: Record<string, any>;
-  newValues?: Record<string, any>;
+  oldValues?: Record<string, unknown>;
+  newValues?: Record<string, unknown>;
   taskId?: string;
-  [key: string]: any;
+  [key: string]: unknown;
+}
+
+interface ActivityTypeCountRaw {
+  activityType: string;
+  count: string;
 }
 
 @Injectable()
@@ -78,8 +83,8 @@ export class ActivityTrackerService {
 
   async trackProfileUpdate(
     userId: string,
-    oldValues: Record<string, any>,
-    newValues: Record<string, any>,
+    oldValues: Record<string, unknown>,
+    newValues: Record<string, unknown>,
     request?: AuthenticatedRequest,
   ): Promise<UserActivity> {
     const changedFields = Object.keys(newValues).filter(
@@ -211,9 +216,9 @@ export class ActivityTrackerService {
       .where('activity.userId = :userId', { userId })
       .groupBy('activity.activityType');
 
-    const activitiesByTypeResult = await activitiesByTypeQuery.getRawMany();
+    const activitiesByTypeResult = await activitiesByTypeQuery.getRawMany() as ActivityTypeCountRaw[];
     const activitiesByType = activitiesByTypeResult.reduce(
-      (acc: Record<ActivityType, number>, item: any) => {
+      (acc: Record<ActivityType, number>, item: ActivityTypeCountRaw) => {
         if (item.activityType in ActivityType) {
           acc[item.activityType as ActivityType] = parseInt(item.count, 10);
         }

--- a/src/shared/cache/cache.service.ts
+++ b/src/shared/cache/cache.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import Redis from 'ioredis';
+import Redis, { RedisOptions } from 'ioredis';
 import { redisConfig } from '../../config/redis.config';
 
 /**
@@ -52,6 +52,10 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
   private hitCount = 0;
   private missCount = 0;
 
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+
   constructor(private readonly configService: ConfigService) {}
 
   /**
@@ -74,7 +78,7 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       retryDelayOnFailover: 100,
       maxRetriesPerRequest: 3,
       lazyConnect: true,
-    } as any);
+    } as RedisOptions);
 
     this.redis.on('connect', () => {
       this.logger.log('Redis connected successfully');
@@ -122,8 +126,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       }
 
       this.logger.debug(`Cache set: ${key} (TTL: ${ttl}s)`);
-    } catch (error: any) {
-      this.logger.error(`Failed to set cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to set cache key ${key}: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -139,9 +143,9 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
    * @param ttl   - TTL in seconds; defaults to the service-level default TTL.
    *                Use {@link CACHE_TTL} constants for category-appropriate lifetimes.
    */
-  async setIfNotExists(
+  async setIfNotExists<T>(
     key: string,
-    value: any,
+    value: T,
     ttl?: number,
   ): Promise<boolean> {
     const effectiveTtl = ttl ?? this.defaultTtl;
@@ -152,7 +156,7 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       const wasSet = result === 'OK';
       this.logger.debug(`Cache setIfNotExists: ${key} (TTL: ${effectiveTtl}s) -> ${wasSet}`);
       return wasSet;
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.logger.error(`Failed to setIfNotExists cache key ${key}:`, error);
       // In case of error, be conservative and allow sending (return true)
       return true;
@@ -176,8 +180,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       this.logger.debug(`Cache hit: ${key}`);
       
       return JSON.parse(value) as T;
-    } catch (error: any) {
-      this.logger.error(`Failed to get cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to get cache key ${key}: ${this.getErrorMessage(error)}`);
       return null;
     }
   }
@@ -189,8 +193,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
     try {
       await this.redis.del(key);
       this.logger.debug(`Cache deleted: ${key}`);
-    } catch (error: any) {
-      this.logger.error(`Failed to delete cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to delete cache key ${key}: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -202,8 +206,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
     try {
       const result = await this.redis.exists(key);
       return result === 1;
-    } catch (error: any) {
-      this.logger.error(`Failed to check cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to check cache key ${key}: ${this.getErrorMessage(error)}`);
       return false;
     }
   }
@@ -215,8 +219,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
     try {
       await this.redis.expire(key, ttl);
       this.logger.debug(`Cache TTL set: ${key} (${ttl}s)`);
-    } catch (error: any) {
-      this.logger.error(`Failed to set TTL for cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to set TTL for cache key ${key}: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -227,8 +231,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
   async ttl(key: string): Promise<number> {
     try {
       return await this.redis.ttl(key);
-    } catch (error: any) {
-      this.logger.error(`Failed to get TTL for cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to get TTL for cache key ${key}: ${this.getErrorMessage(error)}`);
       return -1;
     }
   }
@@ -241,8 +245,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       const result = await this.redis.incrby(key, amount);
       this.logger.debug(`Cache incremented: ${key} by ${amount}`);
       return result;
-    } catch (error: any) {
-      this.logger.error(`Failed to increment cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to increment cache key ${key}: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -255,8 +259,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       const result = await this.redis.decrby(key, amount);
       this.logger.debug(`Cache decremented: ${key} by ${amount}`);
       return result;
-    } catch (error: any) {
-      this.logger.error(`Failed to decrement cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to decrement cache key ${key}: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -264,14 +268,14 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
   /**
    * Add value to a list
    */
-  async lpush(key: string, ...values: any[]): Promise<number> {
+  async lpush<T>(key: string, ...values: T[]): Promise<number> {
     try {
       const serializedValues = values.map(v => JSON.stringify(v));
       const result = await this.redis.lpush(key, ...serializedValues);
       this.logger.debug(`Cache lpush: ${key} (${values.length} items)`);
       return result;
-    } catch (error: any) {
-      this.logger.error(`Failed to lpush cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to lpush cache key ${key}: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -283,8 +287,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
     try {
       const values = await this.redis.lrange(key, start, stop);
       return values.map(v => JSON.parse(v)) as T[];
-    } catch (error: any) {
-      this.logger.error(`Failed to lrange cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to lrange cache key ${key}: ${this.getErrorMessage(error)}`);
       return [];
     }
   }
@@ -292,14 +296,14 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
   /**
    * Add value to a set
    */
-  async sadd(key: string, ...values: any[]): Promise<number> {
+  async sadd<T>(key: string, ...values: T[]): Promise<number> {
     try {
       const serializedValues = values.map(v => JSON.stringify(v));
       const result = await this.redis.sadd(key, ...serializedValues);
       this.logger.debug(`Cache sadd: ${key} (${values.length} items)`);
       return result;
-    } catch (error: any) {
-      this.logger.error(`Failed to sadd cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to sadd cache key ${key}: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -311,8 +315,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
     try {
       const values = await this.redis.smembers(key);
       return values.map(v => JSON.parse(v)) as T[];
-    } catch (error: any) {
-      this.logger.error(`Failed to smembers cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to smembers cache key ${key}: ${this.getErrorMessage(error)}`);
       return [];
     }
   }
@@ -330,8 +334,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       const result = await this.redis.del(...keys);
       this.logger.log(`Cache cleared: ${keys.length} keys matching pattern "${pattern}"`);
       return result;
-    } catch (error: any) {
-      this.logger.error(`Failed to clear cache pattern ${pattern}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to clear cache pattern ${pattern}: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -342,8 +346,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
   async keys(pattern: string): Promise<string[]> {
     try {
       return await this.redis.keys(pattern);
-    } catch (error: any) {
-      this.logger.error(`Failed to get keys for pattern ${pattern}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to get keys for pattern ${pattern}: ${this.getErrorMessage(error)}`);
       return [];
     }
   }
@@ -355,8 +359,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
     try {
       await this.redis.flushall();
       this.logger.log('Cache flushed all');
-    } catch (error: any) {
-      this.logger.error(`Failed to flush cache: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to flush cache: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -383,8 +387,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
         misses: this.missCount,
         hitRate: Math.round(hitRate * 100) / 100,
       };
-    } catch (error: any) {
-      this.logger.error(`Failed to get cache stats: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to get cache stats: ${this.getErrorMessage(error)}`);
       return {
         keys: 0,
         memory: '0B',
@@ -424,8 +428,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       await this.set(key, data, { ttl: effectiveTtl });
       
       return data;
-    } catch (error: any) {
-      this.logger.error(`Failed to remember cache key ${key}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to remember cache key ${key}: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -490,8 +494,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
           return null;
         }
       });
-    } catch (error: any) {
-      this.logger.error(`Failed to mget cache keys: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to mget cache keys: ${this.getErrorMessage(error)}`);
       return keys.map(() => null);
     }
   }
@@ -499,7 +503,7 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
   /**
    * Set multiple keys at once
    */
-  async mset(keyValuePairs: Record<string, any>, ttl?: number): Promise<void> {
+  async mset<T>(keyValuePairs: Record<string, T>, ttl?: number): Promise<void> {
     try {
       const serializedPairs: string[] = [];
       
@@ -519,8 +523,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       }
 
       this.logger.debug(`Cache mset: ${Object.keys(keyValuePairs).length} keys`);
-    } catch (error: any) {
-      this.logger.error(`Failed to mset cache: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to mset cache: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -551,8 +555,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       await this.set(cacheKey, result, { ttl });
 
       return result;
-    } catch (error: any) {
-      this.logger.error(`Failed to get or compute leaderboard ${cacheKey}: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to get or compute leaderboard ${cacheKey}: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }
@@ -565,8 +569,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
       const count = await this.clearPattern(pattern);
       this.logger.log(`Invalidated ${count} leaderboard cache keys`);
       return count;
-    } catch (error: any) {
-      this.logger.error(`Failed to invalidate leaderboard cache: ${error?.message || error}`);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to invalidate leaderboard cache: ${this.getErrorMessage(error)}`);
       throw error;
     }
   }


### PR DESCRIPTION
## Description
<!-- Summarize the changes and the motivation behind them. Link the related issue below. -->

This Pull Request introduces strict TypeScript type-safety across four modules by removing `any` type annotations, replacing them with accurate DTO structures, concrete interfaces, or generics. 

By eliminating the `any` keyword, we prevent silent runtime failures and allow the TypeScript compiler to catch type mismatches during development.

### Detailed Scope of Fixes:
1. **Cache Service (#1101)**:
   * The `CacheService` had 27 instances of `any` type casting. Catch blocks previously mapped to `catch (error: any)`. These have been refactored to `catch (error: unknown)` with error messages safely parsed via a new utility helper method `getErrorMessage(error: unknown): string`.
   * Redis initialization parameters have been typed using `RedisOptions` instead of `as any`.
   * Generic types (`<T>`) have been introduced for collection/write parameters (`lpush`, `sadd`, `mset`, and `setIfNotExists`) to verify cached data structures at compile time.
2. **JWT Refresh Strategy (#1102)**:
   * Replaced the implicit `payload: any` inside `JwtRefreshStrategy.validate` with a concrete `JwtRefreshPayload` interface containing fields `sub`, `email`, `role`, and `tokenId`.
3. **Activity Tracker Service (#1106)**:
   * Refactored `ActivityMetadata` to use index signature `[key: string]: unknown` instead of `any`.
   * Replaced `any` records on `trackProfileUpdate` parameters with `Record<string, unknown>`.
   * Typed raw SQL query aggregate outputs by mapping database results to an `ActivityTypeCountRaw` interface inside `getActivityStats`.
4. **Task Reminder Entity (#1107)**:
   * Created a concrete `DeliveryTracking` interface for task reminder logs.
   * Replaced the column annotation `deliveryTracking: any;` with `deliveryTracking: DeliveryTracking | null;`.

Closes #1101
Closes #1102
Closes #1106
Closes #1107

## Type of Change
<!-- Check all that apply. -->
- [x] Refactor / code cleanup

## How Has This Been Tested?
<!-- Describe the tests you ran and how to reproduce them. -->
- [x] Unit tests
- [x] Manual testing

### Verification Details:
1. Ran individual TypeScript compiler verification on the refactored files:
   ```bash
   npx tsc src/modules/auth/strategies/jwt-refresh.strategy.ts src/shared/cache/cache.service.ts src/database/entities/task-reminder.entity.ts src/modules/users/services/activity-tracker.service.ts --noEmit --skipLibCheck
   ```
2. Ran unit test suite for local changes:
   ```bash
   npx jest src/shared/cache/cache.service.spec.ts
   ```
