### PR TITLE
docs: add class-level JSDoc comment to RateLimitGuard

### DIFF
--- a/src/common/guards/rate-limit.guard.ts
+++ b/src/common/guards/rate-limit.guard.ts
@@ -10,6 +10,13 @@ import {
 } from '@nestjs/throttler';
 import { Request } from 'express';
 
+/**
+ * Guard that enforces the API rate-limiting rule by tracking requests per
+ * client IP address. It allows a request when the client is within the
+ * configured rate limit and denies access by throwing a 429 Too Many
+ * Requests exception when the client exceeds the allowed number of requests
+ * within the throttling window.
+ */
 @Injectable()
 export class RateLimitGuard extends ThrottlerGuard {
   /**


### PR DESCRIPTION
## Description
This PR adds a class-level `/** ... */` JSDoc comment to the `RateLimitGuard` in `src/common/guards/rate-limit.guard.ts`. Previously the guard class had no top-level comment, making it unclear what access rule it enforces.

The comment documents that the guard:
- Enforces the API rate-limiting rule by tracking requests per client IP address
- Allows a request when the client is within the configured rate limit
- Denies access by throwing a 429 Too Many Requests exception when the client exceeds the allowed number of requests within the throttling window

## Changes
- Added a class-level JSDoc comment above `RateLimitGuard`

Closes #1255