### PR TITLE
Add Swagger response/property decorators and fix any types

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AppService } from './app.service';
 
 @ApiTags('health')
@@ -9,6 +9,7 @@ export class AppController {
 
   @Get('health')
   @ApiOperation({ summary: 'Health check endpoint' })
+  @ApiResponse({ status: 200, description: 'Service is healthy' })
   getHealth() {
     return this.appService.getHealth();
   }
@@ -20,6 +21,7 @@ export class AppController {
 
   @Get()
   @ApiOperation({ summary: 'Welcome message' })
+  @ApiResponse({ status: 200, description: 'Welcome message retrieved successfully' })
   getWelcome() {
     return this.appService.getWelcome();
   }

--- a/src/modules/usage/usage.service.ts
+++ b/src/modules/usage/usage.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Between } from 'typeorm';
+import { Repository, Between, FindOptionsWhere } from 'typeorm';
 import { Usage } from './entities/usage.entity';
 import { NotificationService } from '../../notifications/services/notification.service';
 
@@ -17,7 +17,7 @@ export class UsageService {
     userId: number,
     event: string,
     amount: number = 1,
-    metadata?: any
+    metadata?: Record<string, unknown>
   ): Promise<void> {
     const usage = this.usageRepository.create({
       userId,
@@ -37,7 +37,7 @@ export class UsageService {
     startDate?: Date,
     endDate?: Date
   ): Promise<Usage[]> {
-    const where: any = { userId };
+    const where: FindOptionsWhere<Usage> = { userId };
     if (event) where.event = event;
     if (startDate && endDate) where.createdAt = Between(startDate, endDate);
 

--- a/src/otp/payout-history-query.dto.ts
+++ b/src/otp/payout-history-query.dto.ts
@@ -1,8 +1,10 @@
 import { IsOptional, IsEnum, IsDateString, IsInt, Min } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { RewardStatus } from '../enums/reward-status.enum';
 
 export class PayoutHistoryQueryDto {
+  @ApiPropertyOptional({ description: 'Page number to retrieve', example: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -15,17 +17,21 @@ export class PayoutHistoryQueryDto {
   // @Min(1)
   // limit?: number = 20;
 
+  @ApiPropertyOptional({ description: 'Filter payouts from this date (ISO 8601)', example: '2026-01-01' })
   @IsOptional()
   @IsDateString()
   startDate?: string;
 
+  @ApiPropertyOptional({ description: 'Filter payouts up to this date (ISO 8601)', example: '2026-12-31' })
   @IsOptional()
   @IsDateString()
   endDate?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by payout status', enum: RewardStatus, example: RewardStatus.SUCCESS })
   @IsOptional()
   @IsEnum(RewardStatus)
   status?: RewardStatus;
 
+  @ApiPropertyOptional({ description: 'Filter by reward category id' })
   categoryId?: string;
 }

--- a/src/streaks/streaks.controller.ts
+++ b/src/streaks/streaks.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '@modules/auth/guards/jwt-auth.guard';
 import { StreaksService } from './streaks.service';
 
@@ -12,6 +12,8 @@ export class StreaksController {
 
   @Get()
   @ApiOperation({ summary: 'Get current streak for the authenticated user' })
+  @ApiResponse({ status: 200, description: 'Current streak retrieved successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getCurrentStreak(@Req() req: any) {
     const userId = req.user?.id || req.user?.userId || req.user?.sub;
     return this.streaksService.getCurrentStreak(userId);
@@ -19,6 +21,8 @@ export class StreaksController {
 
   @Get('me')
   @ApiOperation({ summary: 'Get my streak summary' })
+  @ApiResponse({ status: 200, description: 'Streak summary retrieved successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getMyStreak(@Req() req: any) {
     const userId = req.user?.id || req.user?.userId || req.user?.sub;
     const streak = await this.streaksService.getCurrentStreak(userId);
@@ -31,6 +35,8 @@ export class StreaksController {
 
   @Get('history')
   @ApiOperation({ summary: 'Get streak history for the authenticated user' })
+  @ApiResponse({ status: 200, description: 'Streak history retrieved successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getHistory(@Req() req: any) {
     const userId = req.user?.id || req.user?.userId || req.user?.sub;
     return this.streaksService.getStreakHistory(userId);


### PR DESCRIPTION
Closes #1250
Closes #1249
Closes #1159
Closes #1111

- #1250: Added `@ApiResponse` decorators (success + 401) to all three route handlers in `src/streaks/streaks.controller.ts`.
- #1249: Added `@ApiResponse` decorators to the `health` and root route handlers in `src/app.controller.ts`.
- #1159: Added `@ApiPropertyOptional` decorators (with descriptions/examples) to all fields in `src/otp/payout-history-query.dto.ts`.
- #1111: Replaced the two `any` usages in `src/modules/usage/usage.service.ts` with `Record<string, unknown>` for `metadata` and `FindOptionsWhere<Usage>` for the `where` clause.