### PR TITLE
fix: replace any type with JwtPayload interface in jwt.strategy.ts

### DIFF
--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -3,6 +3,15 @@ import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
+export interface JwtPayload {
+  /** The subject claim — typically the user's ID */
+  sub: string;
+  email: string;
+  roles?: string[];
+  iat?: number;
+  exp?: number;
+}
+
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(private readonly configService: ConfigService) {
@@ -14,7 +23,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     });
   }
 
-  async validate(payload: any) {
+  async validate(payload: JwtPayload) {
     return { userId: payload.sub, email: payload.email, roles: payload.roles };
   }
 }


### PR DESCRIPTION
## Summary

Closes #1100

Replaces `payload: any` in `JwtStrategy.validate()` with a proper `JwtPayload` interface, restoring TypeScript type safety.

## Changes

- **Added** exported `JwtPayload` interface in `jwt.strategy.ts`:
  - `sub: string` — JWT subject claim (user ID)
  - `email: string` — user email
  - `roles?: string[]` — optional roles array
  - `iat?: number` — issued-at claim (standard JWT)
  - `exp?: number` — expiry claim (standard JWT)
- **Replaced** `payload: any` → `payload: JwtPayload` in `validate()`

## Testing

- `tsc --noEmit` passes with no new errors introduced by this change.