### PR TITLE
Add @ApiResponse decorators FIX

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.40.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.7.0",
     "jest-util": "^29.7.0",

--- a/src/tasks/assignment/task-assignment.controller.ts
+++ b/src/tasks/assignment/task-assignment.controller.ts
@@ -2,7 +2,8 @@
 import { Controller, Get, UseGuards, Request } from '@nestjs/common';
 import { TaskAssignmentService } from './task-assignment.service';
 import { JwtAuthGuard } from '@modules/auth/guards/jwt-auth.guard';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { User } from '../../entities/user.entity';
 
 @ApiTags('Tasks')
 @ApiBearerAuth()
@@ -15,7 +16,12 @@ export class TaskAssignmentController {
   @ApiOperation({
     summary: "Get or generate today's personalized task assignment",
   })
-  async getTodayTasks(@Request() req) {
+  @ApiResponse({
+    status: 200,
+    description: "Today's task assignment retrieved successfully",
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getTodayTasks(@Request() req: { user: User }) {
     return this.assignmentService.getTodayAssignment(req.user);
   }
 }


### PR DESCRIPTION
Description
This PR updates TaskAssignmentController (src/tasks/assignment/task-assignment.controller.ts) by adding the missing Swagger @ApiResponse decorators (@ApiResponse({ status: 200, ... }) and @ApiResponse({ status: 401, ... })) to ensure that Swagger documentation correctly displays the expected status codes and response shapes for the endpoints.

Closes #--

Type of Change
 Bug fix
 New feature
 Breaking change
 Refactor / code cleanup
 Documentation update
 CI/CD or configuration change
How Has This Been Tested?
 Unit tests
 Integration tests
 Manual testing / code review and linter validation (npx eslint)
Checklist
 My code follows the project's style guidelines (npm run lint passes)
 I have performed a self-review of my code
 I have added or updated tests that cover my changes
 All existing tests pass (npm run test)
 I have updated relevant documentation (README, JSDoc, Swagger, etc.)
 No secrets or sensitive data are included in this PR
 The branch is up to date with main
Screenshots / Logs (if applicable)
TypeScript

  @Get('today')
  @ApiOperation({
    summary: "Get or generate today's personalized task assignment",
  })
  @ApiResponse({
    status: 200,
    description: "Today's task assignment retrieved successfully",
  })
  @ApiResponse({ status: 401, description: 'Unauthorized' })
  async getTodayTasks(@Request() req: { user: User }) {
    return this.assignmentService.getTodayAssignment(req.user);
  }
  
  Closes #1254 